### PR TITLE
Flatbuffer namespace refactor

### DIFF
--- a/client/dfclient/include/fb_util.hpp
+++ b/client/dfclient/include/fb_util.hpp
@@ -1,11 +1,11 @@
 #pragma once
 #include "../../../common/deadfish_generated.h"
 
-#define FBUtilGetServerEvent(DATA, TYPE) GetServerEvent<DeadFish::TYPE>(DATA, DeadFish::ServerMessageUnion_##TYPE)
+#define FBUtilGetServerEvent(DATA, TYPE) GetServerEvent<FlatBuffGenerated::TYPE>(DATA, FlatBuffGenerated::ServerMessageUnion_##TYPE)
 
 template<typename T>
-const T *GetServerEvent(const std::string& data, DeadFish::ServerMessageUnion type) {
-    auto serverMessage = flatbuffers::GetRoot<DeadFish::ServerMessage>(data.data());
+const T *GetServerEvent(const std::string& data, FlatBuffGenerated::ServerMessageUnion type) {
+    auto serverMessage = flatbuffers::GetRoot<FlatBuffGenerated::ServerMessage>(data.data());
     if (serverMessage->event_type() != type)
         return nullptr;
     return (const T *)serverMessage->event();

--- a/client/dfclient/include/gameplay_state.hpp
+++ b/client/dfclient/include/gameplay_state.hpp
@@ -23,7 +23,7 @@ const int MOBS_LAYER = 16384;
 struct Mob {
 	std::unique_ptr<ncine::AnimatedSprite> sprite;
 	bool seen;
-	DeadFish::MobState state = DeadFish::MobState_Walk;
+	FlatBuffGenerated::MobState state = FlatBuffGenerated::MobState_Walk;
 	std::unique_ptr<ncine::Sprite> hoverMarker;
 	std::unique_ptr<ncine::Sprite> relationMarker;
 
@@ -32,7 +32,7 @@ struct Mob {
 	float prevRotation = 0.f;
 	float currRotation = 0.f;
 
-	void setupLocRot(const DeadFish::Mob& msg);
+	void setupLocRot(const FlatBuffGenerated::Mob& msg);
 	void updateLocRot(float subDelta);
 };
 
@@ -50,8 +50,8 @@ struct GameplayState
 	void OnKeyPressed(const ncine::KeyboardEvent &event) override;
 	void OnKeyReleased(const ncine::KeyboardEvent &event) override;
 	void LoadLevel();
-	void ProcessDeathReport(const DeadFish::DeathReport* deathReport);
-	void ProcessHighscoreUpdate(const DeadFish::HighscoreUpdate* highscoreUpdate);
+	void ProcessDeathReport(const FlatBuffGenerated::DeathReport* deathReport);
+	void ProcessHighscoreUpdate(const FlatBuffGenerated::HighscoreUpdate* highscoreUpdate);
 	void CreateTextTween(ncine::TextNode* textPtr);
 	std::unique_ptr<ncine::AnimatedSprite> CreateNewAnimSprite(ncine::SceneNode* parent, uint16_t species);
 	void ToggleHighscores();

--- a/client/dfclient/src/gameplay_state.cpp
+++ b/client/dfclient/src/gameplay_state.cpp
@@ -97,7 +97,7 @@ void GameplayState::CreateTextTween(ncine::TextNode* textPtr) {
 }
 
 // this whole thing should probably be refactored
-void GameplayState::ProcessDeathReport(const DeadFish::DeathReport* deathReport) {
+void GameplayState::ProcessDeathReport(const FlatBuffGenerated::DeathReport* deathReport) {
 	auto& rootNode = ncine::theApplication().rootNode();
 	auto text = std::make_unique<ncine::TextNode>(&rootNode, this->manager.fonts["comic"].get());
 	const float screenWidth = ncine::theApplication().width();
@@ -141,7 +141,7 @@ void GameplayState::ProcessDeathReport(const DeadFish::DeathReport* deathReport)
 	this->nodes.push_back(std::move(text));
 }
 
-void GameplayState::ProcessHighscoreUpdate(const DeadFish::HighscoreUpdate* highscoreUpdate) {
+void GameplayState::ProcessHighscoreUpdate(const FlatBuffGenerated::HighscoreUpdate* highscoreUpdate) {
 	for (int i = 0; i < highscoreUpdate->players()->size(); i++) {
 		auto highscoreEntry = highscoreUpdate->players()->Get(i);
 		// this is ugly, i know
@@ -220,12 +220,12 @@ void GameplayState::OnMessage(const std::string& data) {
 			this->mySprite = mob.sprite.get();
 		}
 
-		if (mobData->relation() == DeadFish::PlayerRelation_None) {
+		if (mobData->relation() == FlatBuffGenerated::PlayerRelation_None) {
 			mob.relationMarker.reset(nullptr);
-		} else if (mobData->relation() == DeadFish::PlayerRelation_Close) {
+		} else if (mobData->relation() == FlatBuffGenerated::PlayerRelation_Close) {
 			mob.relationMarker = std::make_unique<ncine::Sprite>(mob.sprite.get(), manager.textures["bluecircle.png"].get());
 			mob.relationMarker->setColor(ncine::Colorf(1, 1, 1, 0.3));
-		} else if (mobData->relation() == DeadFish::PlayerRelation_Targeted) {
+		} else if (mobData->relation() == FlatBuffGenerated::PlayerRelation_Targeted) {
 			mob.relationMarker = std::make_unique<ncine::Sprite>(mob.sprite.get(), manager.textures["redcircle.png"].get());
 			mob.relationMarker->setColor(ncine::Colorf(1, 1, 1, 0.3));
 		}
@@ -262,7 +262,7 @@ void GameplayState::OnMessage(const std::string& data) {
 	}
 }
 
-void Mob::setupLocRot(const DeadFish::Mob& msg) {
+void Mob::setupLocRot(const FlatBuffGenerated::Mob& msg) {
 	prevPosition = currPosition;
 	prevRotation = currRotation;
 
@@ -384,9 +384,9 @@ void GameplayState::OnMouseButtonPressed(const ncine::MouseEvent &event) {
 		const float serverX = (this->mySprite->position().x + (event.x - screenWidth / 2) * 1.5f) * PIXELS2METERS;
 		const float serverY = -(this->mySprite->position().y + (event.y - screenHeight / 2) * 1.5f) * PIXELS2METERS;
 		flatbuffers::FlatBufferBuilder builder;
-		auto pos = DeadFish::Vec2(serverX, serverY);
-		auto cmdMove = DeadFish::CreateCommandMove(builder, &pos);
-		auto message = DeadFish::CreateClientMessage(builder, DeadFish::ClientMessageUnion_CommandMove, cmdMove.Union());
+		auto pos = FlatBuffGenerated::Vec2(serverX, serverY);
+		auto cmdMove = FlatBuffGenerated::CreateCommandMove(builder, &pos);
+		auto message = FlatBuffGenerated::CreateClientMessage(builder, FlatBuffGenerated::ClientMessageUnion_CommandMove, cmdMove.Union());
 		builder.Finish(message);
 		SendData(builder);
 	}
@@ -396,8 +396,8 @@ void GameplayState::OnMouseButtonPressed(const ncine::MouseEvent &event) {
 			if (mob.second.hoverMarker.get()) {
 				// if it is hovered kill it
 				flatbuffers::FlatBufferBuilder builder;
-				auto cmdKill = DeadFish::CreateCommandKill(builder, mob.first);
-				auto message = DeadFish::CreateClientMessage(builder, DeadFish::ClientMessageUnion_CommandKill, cmdKill.Union());
+				auto cmdKill = FlatBuffGenerated::CreateCommandKill(builder, mob.first);
+				auto message = FlatBuffGenerated::CreateClientMessage(builder, FlatBuffGenerated::ClientMessageUnion_CommandKill, cmdKill.Union());
 				builder.Finish(message);
 				SendData(builder);
 				break;
@@ -408,8 +408,8 @@ void GameplayState::OnMouseButtonPressed(const ncine::MouseEvent &event) {
 
 void SendCommandRun(bool run) {
 	flatbuffers::FlatBufferBuilder builder;
-	auto cmdRun = DeadFish::CreateCommandRun(builder, run);
-	auto message = DeadFish::CreateClientMessage(builder, DeadFish::ClientMessageUnion_CommandRun, cmdRun.Union());
+	auto cmdRun = FlatBuffGenerated::CreateCommandRun(builder, run);
+	auto message = FlatBuffGenerated::CreateClientMessage(builder, FlatBuffGenerated::ClientMessageUnion_CommandRun, cmdRun.Union());
 	builder.Finish(message);
 	SendData(builder);
 }

--- a/client/dfclient/src/lobby_state.cpp
+++ b/client/dfclient/src/lobby_state.cpp
@@ -44,8 +44,8 @@ void LobbyState::Create() {
 	// if we're here then that means that the socket has already connected, send data
 	gameData.socket->onMessage = std::bind(&LobbyState::OnMessage, this, std::placeholders::_1);
 	flatbuffers::FlatBufferBuilder builder;
-	auto req = DeadFish::CreateJoinRequest(builder, builder.CreateString(gameData.myNickname));
-	auto message = DeadFish::CreateClientMessage(builder, DeadFish::ClientMessageUnion_JoinRequest, req.Union());
+	auto req = FlatBuffGenerated::CreateJoinRequest(builder, builder.CreateString(gameData.myNickname));
+	auto message = FlatBuffGenerated::CreateClientMessage(builder, FlatBuffGenerated::ClientMessageUnion_JoinRequest, req.Union());
 	builder.Finish(message);
 
 	SendData(builder);
@@ -103,8 +103,8 @@ void LobbyState::RedrawPlayers() {
 
 void LobbyState::SendPlayerReady() {
 	flatbuffers::FlatBufferBuilder builder;
-	auto ready = DeadFish::CreatePlayerReady(builder);
-	auto message = DeadFish::CreateClientMessage(builder, DeadFish::ClientMessageUnion_PlayerReady, ready.Union());
+	auto ready = FlatBuffGenerated::CreatePlayerReady(builder);
+	auto message = FlatBuffGenerated::CreateClientMessage(builder, FlatBuffGenerated::ClientMessageUnion_PlayerReady, ready.Union());
 	builder.Finish(message);
 
 	SendData(builder);

--- a/deadfish.fbs
+++ b/deadfish.fbs
@@ -1,4 +1,4 @@
-namespace DeadFish;
+namespace FlatBuffGenerated;
 
 // level
 

--- a/levelpacker/levelpacker.py
+++ b/levelpacker/levelpacker.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 import configparser, os, json, flatbuffers
-import DeadFish.Bush, DeadFish.Level, DeadFish.Stone, \
-    DeadFish.Vec2, DeadFish.NavPoint, DeadFish.PlayerWall
+import FlatBuffGenerated.Bush, FlatBuffGenerated.Level, FlatBuffGenerated.Stone, \
+    FlatBuffGenerated.Vec2, FlatBuffGenerated.NavPoint, FlatBuffGenerated.PlayerWall
 from functools import reduce
 import xml.dom.minidom as minidom
 from collections import namedtuple
@@ -34,18 +34,18 @@ def handle_objects(g: minidom.Node, objs: GameObjects, builder: flatbuffers.Buil
         gid = int(o.getAttribute('gid'))
 
         if gid == 1:
-            DeadFish.Bush.BushStart(builder)
-            DeadFish.Bush.BushAddRadius(builder, radius * GLOBAL_SCALE)
-            pos = DeadFish.Vec2.CreateVec2(builder, x * GLOBAL_SCALE, y * GLOBAL_SCALE)
-            DeadFish.Bush.BushAddPos(builder, pos)
-            objs.bushes.append(DeadFish.Bush.BushEnd(builder))
+            FlatBuffGenerated.Bush.BushStart(builder)
+            FlatBuffGenerated.Bush.BushAddRadius(builder, radius * GLOBAL_SCALE)
+            pos = FlatBuffGenerated.Vec2.CreateVec2(builder, x * GLOBAL_SCALE, y * GLOBAL_SCALE)
+            FlatBuffGenerated.Bush.BushAddPos(builder, pos)
+            objs.bushes.append(FlatBuffGenerated.Bush.BushEnd(builder))
 
         elif gid == 2:
-            DeadFish.Stone.StoneStart(builder)
-            DeadFish.Stone.StoneAddRadius(builder, radius * GLOBAL_SCALE)
-            pos = DeadFish.Vec2.CreateVec2(builder, x * GLOBAL_SCALE, y * GLOBAL_SCALE)
-            DeadFish.Stone.StoneAddPos(builder, pos)
-            objs.stones.append(DeadFish.Stone.StoneEnd(builder))
+            FlatBuffGenerated.Stone.StoneStart(builder)
+            FlatBuffGenerated.Stone.StoneAddRadius(builder, radius * GLOBAL_SCALE)
+            pos = FlatBuffGenerated.Vec2.CreateVec2(builder, x * GLOBAL_SCALE, y * GLOBAL_SCALE)
+            FlatBuffGenerated.Stone.StoneAddPos(builder, pos)
+            objs.stones.append(FlatBuffGenerated.Stone.StoneEnd(builder))
 
 
 def handle_meta(g: minidom.Node, objs: GameObjects, builder: flatbuffers.Builder):
@@ -58,12 +58,12 @@ def handle_meta(g: minidom.Node, objs: GameObjects, builder: flatbuffers.Builder
             width = float(o.getAttribute('width')) / 2.0
             height = float(o.getAttribute('height')) / 2.0
 
-            DeadFish.PlayerWall.PlayerWallStart(builder)
-            pos = DeadFish.Vec2.CreateVec2(builder, x * GLOBAL_SCALE, y * GLOBAL_SCALE)
-            DeadFish.PlayerWall.PlayerWallAddPosition(builder, pos)
-            size = DeadFish.Vec2.CreateVec2(builder, width * GLOBAL_SCALE, height * GLOBAL_SCALE)
-            DeadFish.PlayerWall.PlayerWallAddSize(builder, size)
-            pwall = DeadFish.PlayerWall.PlayerWallEnd(builder)
+            FlatBuffGenerated.PlayerWall.PlayerWallStart(builder)
+            pos = FlatBuffGenerated.Vec2.CreateVec2(builder, x * GLOBAL_SCALE, y * GLOBAL_SCALE)
+            FlatBuffGenerated.PlayerWall.PlayerWallAddPosition(builder, pos)
+            size = FlatBuffGenerated.Vec2.CreateVec2(builder, width * GLOBAL_SCALE, height * GLOBAL_SCALE)
+            FlatBuffGenerated.PlayerWall.PlayerWallAddSize(builder, size)
+            pwall = FlatBuffGenerated.PlayerWall.PlayerWallEnd(builder)
             objs.playerwalls.append(pwall)
 
         elif typ == 'waypoint':
@@ -94,19 +94,19 @@ def handle_meta(g: minidom.Node, objs: GameObjects, builder: flatbuffers.Builder
 
             name = builder.CreateString(name)
             neighOff = [builder.CreateString(x) for x in neighbors]
-            DeadFish.NavPoint.NavPointStartNeighborsVector(builder, len(neighOff))
+            FlatBuffGenerated.NavPoint.NavPointStartNeighborsVector(builder, len(neighOff))
             for b in neighOff:
                 builder.PrependUOffsetTRelative(b)
             neighs = builder.EndVector(len(neighOff))
-            DeadFish.NavPoint.NavPointStart(builder)
-            pos = DeadFish.Vec2.CreateVec2(builder, x * GLOBAL_SCALE, y * GLOBAL_SCALE)
-            DeadFish.NavPoint.NavPointAddPosition(builder, pos)
-            DeadFish.NavPoint.NavPointAddRadius(builder, radius)
-            DeadFish.NavPoint.NavPointAddName(builder, name)
-            DeadFish.NavPoint.NavPointAddNeighbors(builder, neighs)
-            DeadFish.NavPoint.NavPointAddIsspawn(builder, isspawn)
-            DeadFish.NavPoint.NavPointAddIsplayerspawn(builder, isplayerspawn)
-            objs.navpoints.append(DeadFish.NavPoint.NavPointEnd(builder))
+            FlatBuffGenerated.NavPoint.NavPointStart(builder)
+            pos = FlatBuffGenerated.Vec2.CreateVec2(builder, x * GLOBAL_SCALE, y * GLOBAL_SCALE)
+            FlatBuffGenerated.NavPoint.NavPointAddPosition(builder, pos)
+            FlatBuffGenerated.NavPoint.NavPointAddRadius(builder, radius)
+            FlatBuffGenerated.NavPoint.NavPointAddName(builder, name)
+            FlatBuffGenerated.NavPoint.NavPointAddNeighbors(builder, neighs)
+            FlatBuffGenerated.NavPoint.NavPointAddIsspawn(builder, isspawn)
+            FlatBuffGenerated.NavPoint.NavPointAddIsplayerspawn(builder, isplayerspawn)
+            objs.navpoints.append(FlatBuffGenerated.NavPoint.NavPointEnd(builder))
 
 
 def process_level(path: str):
@@ -124,36 +124,36 @@ def process_level(path: str):
         else:
             print("WARNING: Unknown group {}".format(group_name))
     
-    DeadFish.Level.LevelStartBushesVector(builder, len(objs.bushes))
+    FlatBuffGenerated.Level.LevelStartBushesVector(builder, len(objs.bushes))
     for b in objs.bushes:
         builder.PrependUOffsetTRelative(b)
     bushesOff = builder.EndVector(len(objs.bushes))
 
-    DeadFish.Level.LevelStartStonesVector(builder, len(objs.stones))
+    FlatBuffGenerated.Level.LevelStartStonesVector(builder, len(objs.stones))
     for b in objs.stones:
         builder.PrependUOffsetTRelative(b)
     stonesOff = builder.EndVector(len(objs.stones))
 
-    DeadFish.Level.LevelStartNavpointsVector(builder, len(objs.navpoints))
+    FlatBuffGenerated.Level.LevelStartNavpointsVector(builder, len(objs.navpoints))
     for b in objs.navpoints:
         builder.PrependUOffsetTRelative(b)
     navpointsOff = builder.EndVector(len(objs.navpoints))
 
-    DeadFish.Level.LevelStartPlayerwallsVector(builder, len(objs.playerwalls))
+    FlatBuffGenerated.Level.LevelStartPlayerwallsVector(builder, len(objs.playerwalls))
     for b in objs.playerwalls:
         builder.PrependUOffsetTRelative(b)
     playerwallsOff = builder.EndVector(len(objs.playerwalls))
 
-    DeadFish.Level.LevelStart(builder)
-    DeadFish.Level.LevelAddBushes(builder, bushesOff)
-    DeadFish.Level.LevelAddStones(builder, stonesOff)
-    DeadFish.Level.LevelAddNavpoints(builder, navpointsOff)
-    DeadFish.Level.LevelAddPlayerwalls(builder, playerwallsOff)
-    size = DeadFish.Vec2.CreateVec2(builder,
+    FlatBuffGenerated.Level.LevelStart(builder)
+    FlatBuffGenerated.Level.LevelAddBushes(builder, bushesOff)
+    FlatBuffGenerated.Level.LevelAddStones(builder, stonesOff)
+    FlatBuffGenerated.Level.LevelAddNavpoints(builder, navpointsOff)
+    FlatBuffGenerated.Level.LevelAddPlayerwalls(builder, playerwallsOff)
+    size = FlatBuffGenerated.Vec2.CreateVec2(builder,
         float(map_node.getAttribute("width")) * float(map_node.getAttribute("tilewidth")) * GLOBAL_SCALE,
         float(map_node.getAttribute("height")) * float(map_node.getAttribute("tileheight")) * GLOBAL_SCALE)
-    DeadFish.Level.LevelAddSize(builder, size)
-    level = DeadFish.Level.LevelEnd(builder)
+    FlatBuffGenerated.Level.LevelAddSize(builder, size)
+    level = FlatBuffGenerated.Level.LevelEnd(builder)
     builder.Finish(level)
 
     buf = builder.Output()

--- a/server/game_thread.cpp
+++ b/server/game_thread.cpp
@@ -39,10 +39,10 @@ uint16_t newMobID()
 }
 
 std::string makeServerMessage(flatbuffers::FlatBufferBuilder &builder,
-							  DeadFish::ServerMessageUnion type,
+							  FlatBuffGenerated::ServerMessageUnion type,
 							  flatbuffers::Offset<void> offset)
 {
-	auto message = DeadFish::CreateServerMessage(builder,
+	auto message = FlatBuffGenerated::CreateServerMessage(builder,
 												 type,
 												 offset);
 	builder.Finish(message);
@@ -54,7 +54,7 @@ std::string makeServerMessage(flatbuffers::FlatBufferBuilder &builder,
 
 void sendServerMessage(Player &player,
 					   flatbuffers::FlatBufferBuilder &builder,
-					   DeadFish::ServerMessageUnion type,
+					   FlatBuffGenerated::ServerMessageUnion type,
 					   flatbuffers::Offset<void> offset)
 {
 	auto str = makeServerMessage(builder, type, offset);
@@ -141,7 +141,7 @@ float revLerp(float min, float max, float val)
 	return (val - min) / (max - min);
 }
 
-flatbuffers::Offset<DeadFish::Indicator>
+flatbuffers::Offset<FlatBuffGenerated::Indicator>
 makePlayerIndicator(flatbuffers::FlatBufferBuilder &builder,
 					Player &rootPlayer,
 					Player &otherPlayer)
@@ -151,33 +151,33 @@ makePlayerIndicator(flatbuffers::FlatBufferBuilder &builder,
 	float angle = 0;
 	if (force != 0)
 		angle = angleFromVector(toTarget);
-	return DeadFish::CreateIndicator(builder, angle,
+	return FlatBuffGenerated::CreateIndicator(builder, angle,
 		force, playerSeeMob(rootPlayer, otherPlayer));
 }
 
-flatbuffers::Offset<DeadFish::Mob> createFBMob(flatbuffers::FlatBufferBuilder &builder,
+flatbuffers::Offset<FlatBuffGenerated::Mob> createFBMob(flatbuffers::FlatBufferBuilder &builder,
 	Player& player, const Mob* m)
 {
 	auto distance = b2Distance(m->body->GetPosition(), player.body->GetPosition());
-	DeadFish::PlayerRelation relation = DeadFish::PlayerRelation_None;
+	FlatBuffGenerated::PlayerRelation relation = FlatBuffGenerated::PlayerRelation_None;
 	if (distance < KILL_DISTANCE && player.mobID != m->mobID)
-		relation = DeadFish::PlayerRelation_Close;
+		relation = FlatBuffGenerated::PlayerRelation_Close;
 	if (player.killTarget == m)
-		relation = DeadFish::PlayerRelation_Targeted;
-	auto posVec = DeadFish::Vec2(m->body->GetPosition().x, m->body->GetPosition().y);
-	return DeadFish::CreateMob(builder,
+		relation = FlatBuffGenerated::PlayerRelation_Targeted;
+	auto posVec = FlatBuffGenerated::Vec2(m->body->GetPosition().x, m->body->GetPosition().y);
+	return FlatBuffGenerated::CreateMob(builder,
 									m->mobID,
 									&posVec,
 									m->body->GetAngle(),
-									(DeadFish::MobState)m->state,
+									(FlatBuffGenerated::MobState)m->state,
 									m->species,
 									relation);
 }
 
 flatbuffers::Offset<void> makeWorldState(Player &player, flatbuffers::FlatBufferBuilder &builder)
 {
-	std::vector<flatbuffers::Offset<DeadFish::Mob>> mobs;
-	std::vector<flatbuffers::Offset<DeadFish::Indicator>> indicators;
+	std::vector<flatbuffers::Offset<FlatBuffGenerated::Mob>> mobs;
+	std::vector<flatbuffers::Offset<FlatBuffGenerated::Indicator>> indicators;
 	for (auto &c : gameState.civilians)
 	{
 		if (!playerSeeMob(player, *c))
@@ -208,7 +208,7 @@ flatbuffers::Offset<void> makeWorldState(Player &player, flatbuffers::FlatBuffer
 	auto mobsOffset = builder.CreateVector(mobs);
 	auto indicatorsOffset = builder.CreateVector(indicators);
 
-	auto worldState = DeadFish::CreateWorldState(builder, mobsOffset, indicatorsOffset);
+	auto worldState = FlatBuffGenerated::CreateWorldState(builder, mobsOffset, indicatorsOffset);
 
 	return worldState.Union();
 }
@@ -365,29 +365,29 @@ void executeCommandKill(Player &player, uint16_t id)
 	}
 	// send message too far
 	flatbuffers::FlatBufferBuilder builder(1);
-	auto ev = DeadFish::CreateSimpleServerEvent(builder, DeadFish::SimpleServerEventType_TooFarToKill);
-	sendServerMessage(player, builder, DeadFish::ServerMessageUnion_SimpleServerEvent, ev.Union());
+	auto ev = FlatBuffGenerated::CreateSimpleServerEvent(builder, FlatBuffGenerated::SimpleServerEventType_TooFarToKill);
+	sendServerMessage(player, builder, FlatBuffGenerated::ServerMessageUnion_SimpleServerEvent, ev.Union());
 }
 
 void sendHighscores()
 {
 	flatbuffers::FlatBufferBuilder builder;
-	std::vector<flatbuffers::Offset<DeadFish::HighscoreEntry>> entries;
+	std::vector<flatbuffers::Offset<FlatBuffGenerated::HighscoreEntry>> entries;
 	for (auto &p : gameState.players)
 	{
-		auto entry = DeadFish::CreateHighscoreEntry(builder, p->playerID, p->points);
+		auto entry = FlatBuffGenerated::CreateHighscoreEntry(builder, p->playerID, p->points);
 		entries.push_back(entry);
 	}
 	auto v = builder.CreateVector(entries);
-	auto update = DeadFish::CreateHighscoreUpdate(builder, v);
-	auto data = makeServerMessage(builder, DeadFish::ServerMessageUnion_HighscoreUpdate, update.Union());
+	auto update = FlatBuffGenerated::CreateHighscoreUpdate(builder, v);
+	auto data = makeServerMessage(builder, FlatBuffGenerated::ServerMessageUnion_HighscoreUpdate, update.Union());
 	sendToAll(data);
 }
 
 void gameOnMessage(websocketpp::connection_hdl hdl, const server::message_ptr& msg)
 {
 	const auto payload = msg->get_payload();
-	const auto clientMessage = flatbuffers::GetRoot<DeadFish::ClientMessage>(payload.c_str());
+	const auto clientMessage = flatbuffers::GetRoot<FlatBuffGenerated::ClientMessage>(payload.c_str());
 	const auto guard = gameState.lock();
 
 	auto p = getPlayerByConnHdl(hdl);
@@ -398,7 +398,7 @@ void gameOnMessage(websocketpp::connection_hdl hdl, const server::message_ptr& m
 
 	switch (clientMessage->event_type())
 	{
-	case DeadFish::ClientMessageUnion::ClientMessageUnion_CommandMove:
+	case FlatBuffGenerated::ClientMessageUnion::ClientMessageUnion_CommandMove:
 	{
 		const auto event = clientMessage->event_as_CommandMove();
 		p->targetPosition = glm::vec2(event->target()->x(), event->target()->y());
@@ -407,13 +407,13 @@ void gameOnMessage(websocketpp::connection_hdl hdl, const server::message_ptr& m
 		p->lastAttack = std::chrono::system_clock::from_time_t(0);
 	}
 	break;
-	case DeadFish::ClientMessageUnion::ClientMessageUnion_CommandRun:
+	case FlatBuffGenerated::ClientMessageUnion::ClientMessageUnion_CommandRun:
 	{
 		const auto event = clientMessage->event_as_CommandRun();
 		p->state = event->run() ? MobState::RUNNING : MobState::WALKING;
 	}
 	break;
-	case DeadFish::ClientMessageUnion::ClientMessageUnion_CommandKill:
+	case FlatBuffGenerated::ClientMessageUnion::ClientMessageUnion_CommandKill:
 	{
 		const auto event = clientMessage->event_as_CommandKill();
 		executeCommandKill(*p, event->mobID());
@@ -445,7 +445,7 @@ void gameThread()
 
 		// send level to clients
 		auto levelOffset = serializeLevel(builder);
-		auto data = makeServerMessage(builder, DeadFish::ServerMessageUnion_Level, levelOffset.Union());
+		auto data = makeServerMessage(builder, FlatBuffGenerated::ServerMessageUnion_Level, levelOffset.Union());
 		sendToAll(data);
 
 		// shuffle the players to give them random species
@@ -473,8 +473,8 @@ void gameThread()
 		{
 			// send game end message to everyone
 			builder.Clear();
-			auto ev = DeadFish::CreateSimpleServerEvent(builder, DeadFish::SimpleServerEventType_GameEnded);
-			auto data = makeServerMessage(builder, DeadFish::ServerMessageUnion_SimpleServerEvent, ev.Union());
+			auto ev = FlatBuffGenerated::CreateSimpleServerEvent(builder, FlatBuffGenerated::SimpleServerEventType_GameEnded);
+			auto data = makeServerMessage(builder, FlatBuffGenerated::ServerMessageUnion_SimpleServerEvent, ev.Union());
 			sendToAll(data);
 			// FIXME: Proper closing of all connections, so that this sleep is unnecessary
 			std::this_thread::sleep_for(std::chrono::milliseconds(500));
@@ -515,7 +515,7 @@ void gameThread()
 		{
 			builder.Clear();
 			auto offset = makeWorldState(*p, builder);
-			sendServerMessage(*p, builder, DeadFish::ServerMessageUnion_WorldState, offset);
+			sendServerMessage(*p, builder, FlatBuffGenerated::ServerMessageUnion_WorldState, offset);
 		}
 
 		// Drop the lock

--- a/server/game_thread.hpp
+++ b/server/game_thread.hpp
@@ -9,10 +9,10 @@ void spawnCivilian();
 Player* getPlayerByConnHdl(websocketpp::connection_hdl &hdl);
 void sendServerMessage(Player& player,
 	flatbuffers::FlatBufferBuilder &builder,
-	DeadFish::ServerMessageUnion type,
+	FlatBuffGenerated::ServerMessageUnion type,
 	flatbuffers::Offset<void> offset);
 std::string makeServerMessage(flatbuffers::FlatBufferBuilder &builder,
-	DeadFish::ServerMessageUnion type,
+	FlatBuffGenerated::ServerMessageUnion type,
 	flatbuffers::Offset<void> offset);
 bool mobSeePoint(Mob &m, b2Vec2 &point);
 void sendToAll(std::string &data);

--- a/server/level_loader.cpp
+++ b/server/level_loader.cpp
@@ -3,7 +3,7 @@
 #include "deadfish.hpp"
 #include "level_loader.hpp"
 
-void initPlayerwall(const DeadFish::PlayerWall *pw)
+void initPlayerwall(const FlatBuffGenerated::PlayerWall *pw)
 {
 	std::cout << "playerwall " << pw->position()->x() << "," << pw->position()->y() << "; " << pw->size()->x() << "," << pw->size()->y() << "\n";
 	b2BodyDef myBodyDef;
@@ -23,7 +23,7 @@ void initPlayerwall(const DeadFish::PlayerWall *pw)
 	gameState.level->playerwalls.back()->body = staticBody;
 }
 
-void initStone(Stone *s, const DeadFish::Stone *dfstone)
+void initStone(Stone *s, const FlatBuffGenerated::Stone *dfstone)
 {
 	b2BodyDef myBodyDef;
 	myBodyDef.type = b2_staticBody;
@@ -40,32 +40,32 @@ void initStone(Stone *s, const DeadFish::Stone *dfstone)
 	s->body->SetUserData(s);
 }
 
-flatbuffers::Offset<DeadFish::Level> serializeLevel(flatbuffers::FlatBufferBuilder &builder)
+flatbuffers::Offset<FlatBuffGenerated::Level> serializeLevel(flatbuffers::FlatBufferBuilder &builder)
 {
 	// bushes
-	std::vector<flatbuffers::Offset<DeadFish::Bush>> bushOffsets;
+	std::vector<flatbuffers::Offset<FlatBuffGenerated::Bush>> bushOffsets;
 	for (auto &b : gameState.level->bushes)
 	{
-		DeadFish::Vec2 pos(b->position.x, b->position.y);
-		auto off = DeadFish::CreateBush(builder, b->radius, &pos);
+		FlatBuffGenerated::Vec2 pos(b->position.x, b->position.y);
+		auto off = FlatBuffGenerated::CreateBush(builder, b->radius, &pos);
 		bushOffsets.push_back(off);
 	}
 	auto bushes = builder.CreateVector(bushOffsets);
 
 	// stones
-	std::vector<flatbuffers::Offset<DeadFish::Stone>> stoneOffsets;
+	std::vector<flatbuffers::Offset<FlatBuffGenerated::Stone>> stoneOffsets;
 	for (auto &s : gameState.level->stones)
 	{
-		DeadFish::Vec2 pos(s->body->GetPosition().x, s->body->GetPosition().y);
+		FlatBuffGenerated::Vec2 pos(s->body->GetPosition().x, s->body->GetPosition().y);
 		auto f = s->body->GetFixtureList();
 		auto c = (b2CircleShape *)f->GetShape();
-		auto off = DeadFish::CreateStone(builder, c->m_radius, &pos);
+		auto off = FlatBuffGenerated::CreateStone(builder, c->m_radius, &pos);
 		stoneOffsets.push_back(off);
 	}
 	auto stones = builder.CreateVector(stoneOffsets);
 
-	DeadFish::Vec2 size(gameState.level->size.x, gameState.level->size.y);
-	auto level = DeadFish::CreateLevel(builder, bushes, stones, 0, 0, &size);
+	FlatBuffGenerated::Vec2 size(gameState.level->size.x, gameState.level->size.y);
+	auto level = FlatBuffGenerated::CreateLevel(builder, bushes, stones, 0, 0, &size);
 	return level;
 }
 
@@ -99,7 +99,7 @@ void loadLevel(std::string &path)
 	in.read(memblock.data(), memblock.size());
 	in.close();
 
-	auto level = flatbuffers::GetRoot<DeadFish::Level>(memblock.data());
+	auto level = flatbuffers::GetRoot<FlatBuffGenerated::Level>(memblock.data());
 
 	// bushes
 	for (size_t i = 0; i < level->bushes()->size(); i++)

--- a/server/level_loader.hpp
+++ b/server/level_loader.hpp
@@ -1,4 +1,4 @@
 #pragma once
 
 void loadLevel(std::string& path);
-flatbuffers::Offset<DeadFish::Level> serializeLevel(flatbuffers::FlatBufferBuilder& builder);
+flatbuffers::Offset<FlatBuffGenerated::Level> serializeLevel(flatbuffers::FlatBufferBuilder& builder);

--- a/server/main.cpp
+++ b/server/main.cpp
@@ -13,17 +13,17 @@ void sendInitMetadata()
 	for (auto &targetPlayer : gameState.players)
 	{
 		flatbuffers::FlatBufferBuilder builder(1);
-		std::vector<flatbuffers::Offset<DeadFish::InitPlayer>> playerOffsets;
+		std::vector<flatbuffers::Offset<FlatBuffGenerated::InitPlayer>> playerOffsets;
 		for (size_t i = 0; i < gameState.players.size(); i++)
 		{
 			auto& player = gameState.players[i];
 			auto name = builder.CreateString(player->name.c_str());
-			auto playerOffset = DeadFish::CreateInitPlayer(builder, i, name, player->species, player->ready);
+			auto playerOffset = FlatBuffGenerated::CreateInitPlayer(builder, i, name, player->species, player->ready);
 			playerOffsets.push_back(playerOffset);
 		}
 		auto players = builder.CreateVector(playerOffsets);
-		auto metadata = DeadFish::CreateInitMetadata(builder, players, targetPlayer->mobID, targetPlayer->playerID);
-		sendServerMessage(*targetPlayer, builder, DeadFish::ServerMessageUnion_InitMetadata, metadata.Union());
+		auto metadata = FlatBuffGenerated::CreateInitMetadata(builder, players, targetPlayer->mobID, targetPlayer->playerID);
+		sendServerMessage(*targetPlayer, builder, FlatBuffGenerated::ServerMessageUnion_InitMetadata, metadata.Union());
 	}
 }
 
@@ -51,10 +51,10 @@ void on_message(websocketpp::connection_hdl hdl, const server::message_ptr& msg)
 	std::cout << "message from " << (uint64_t)hdl.lock().get() << "\n";
 
 	const auto payload = msg->get_payload();
-	const auto clientMessage = flatbuffers::GetRoot<DeadFish::ClientMessage>(payload.c_str());
+	const auto clientMessage = flatbuffers::GetRoot<FlatBuffGenerated::ClientMessage>(payload.c_str());
 	switch (clientMessage->event_type())
 	{
-	case DeadFish::ClientMessageUnion::ClientMessageUnion_JoinRequest:
+	case FlatBuffGenerated::ClientMessageUnion::ClientMessageUnion_JoinRequest:
 	{
 		const auto event = clientMessage->event_as_JoinRequest();
 		std::cout << "new player " << event->name()->c_str() << "\n";
@@ -62,7 +62,7 @@ void on_message(websocketpp::connection_hdl hdl, const server::message_ptr& msg)
 		std::cout << "player count " << gameState.players.size() << "\n";
 	}
 	break;
-	case DeadFish::ClientMessageUnion::ClientMessageUnion_PlayerReady:
+	case FlatBuffGenerated::ClientMessageUnion::ClientMessageUnion_PlayerReady:
 	{
 		auto pl = getPlayerByConnHdl(hdl);
 		if (!pl)

--- a/server/mobs.cpp
+++ b/server/mobs.cpp
@@ -245,8 +245,8 @@ void Civilian::handleKill(Player& killer) {
 
 	// send the deathreport killed npc message
 	flatbuffers::FlatBufferBuilder builder;
-	auto ev = DeadFish::CreateDeathReport(builder, killer.playerID, -1);
-	sendServerMessage(killer, builder, DeadFish::ServerMessageUnion_DeathReport, ev.Union());
+	auto ev = FlatBuffGenerated::CreateDeathReport(builder, killer.playerID, -1);
+	sendServerMessage(killer, builder, FlatBuffGenerated::ServerMessageUnion_DeathReport, ev.Union());
 	std::cout << "sent a death report\n";
 
 	sendHighscores();
@@ -273,8 +273,8 @@ void Player::handleKill(Player& killer) {
 
 	// send the deathreport message
 	flatbuffers::FlatBufferBuilder builder;
-	auto ev = DeadFish::CreateDeathReport(builder, killer.playerID, this->playerID);
-	auto data = makeServerMessage(builder, DeadFish::ServerMessageUnion_DeathReport, ev.Union());
+	auto ev = FlatBuffGenerated::CreateDeathReport(builder, killer.playerID, this->playerID);
+	auto data = makeServerMessage(builder, FlatBuffGenerated::ServerMessageUnion_DeathReport, ev.Union());
 	sendToAll(data);
 
 	sendHighscores();


### PR DESCRIPTION
Refactor, polegający na zmianie mylącej nazwy namespace'a generowanych plików flatbufferowych (DeadFish) na bardziej adekwatną (FlatBuffGenerated)