### PR TITLE
Upgrade boost from 1.65.1 to 1.74.0, change websocketpp to boost::beast

### DIFF
--- a/client/dfclient/src/gameplay_state.cpp
+++ b/client/dfclient/src/gameplay_state.cpp
@@ -110,7 +110,7 @@ void GameplayState::LoadLevel() {
 			object->pos()->x() * METERS2PIXELS, -object->pos()->y() * METERS2PIXELS);
 		objectSprite->setAnchorPoint(0, 1);
 		objectSprite->setRotation(-object->rotation());
-		if(object->hspotname()->str().empty()){
+		if (object->hspotname()->str().empty()){
 			objectSprite->setLayer(OBJECTS_LAYER);
 			this->nodes.push_back(std::move(objectSprite));
 		} else {
@@ -309,7 +309,7 @@ void GameplayState::OnMessage(const std::string& data) {
 	updateRemainingText(worldState->stepsRemaining());
 
 	// make current hidingspot transparent
-	if(worldState->currentHidingSpot()->str() != "") {
+	if (worldState->currentHidingSpot()->str() != "") {
 		auto &hspotSprites = this->hiding_spots[worldState->currentHidingSpot()->str()];
 		if (!hspotSprites.empty() && hspotSprites[0]->alpha() == MAX_HIDING_SPOT_OPACITY) {
 			for (auto &hsSprite : hspotSprites) {
@@ -409,7 +409,7 @@ StateType GameplayState::Update(Messages m) {
 		ImGui::PushStyleColor(ImGuiCol_Button, (ImVec4)ImColor::HSV(7.0f, 0.0f, 0.6f));
 		ImGui::PushStyleColor(ImGuiCol_ButtonHovered, (ImVec4)ImColor::HSV(7.0f, 0.0f, 0.7f));
 		ImGui::PushStyleColor(ImGuiCol_ButtonActive, (ImVec4)ImColor::HSV(7.0f, 0.0f, 0.8f));
-		if(ImGui::Button("No")) {
+		if (ImGui::Button("No")) {
 			this->showQuitDialog = false;
 		}
 		ImGui::PopStyleColor(3);

--- a/client/dfclient/src/lobby_state.cpp
+++ b/client/dfclient/src/lobby_state.cpp
@@ -127,7 +127,7 @@ void LobbyState::SendPlayerReady() {
 }
 
 void LobbyState::OnMouseButtonPressed(const ncine::MouseEvent &event) {
-	if(IntersectsNode(event.x, event.y, *this->readyButton) && !this->ready) {
+	if (IntersectsNode(event.x, event.y, *this->readyButton) && !this->ready) {
 		this->ready = true;
 		this->SendPlayerReady();
 	}

--- a/client/dfclient/src/websocket.cpp
+++ b/client/dfclient/src/websocket.cpp
@@ -124,10 +124,10 @@ beast::flat_buffer buffer;
 void DoRead();
 
 void OnRead(beast::error_code ec, std::size_t bytes_transferred) {
-	if(ec == websocket::error::closed)
+	if (ec == websocket::error::closed)
 		return;
 
-	if(ec) {
+	if (ec) {
 		if (ec.value() == boost::system::errc::operation_canceled) {
 			// this websocket has disconnected
 			// todo: cleanup whatever is happening and return to main menu
@@ -153,7 +153,7 @@ int WebSocketBeast::Connect(std::string& fullAddress) {
 
 	ws.binary(true);
 
-	auto address = fullAddress.substr(5, fullAddress.size());
+	auto address = fullAddress.substr(std::string("ws://").size(), fullAddress.size());
 
 	auto colon = address.find(":");
 	if (colon == std::string::npos)

--- a/client/recmake_dfclient_native.sh
+++ b/client/recmake_dfclient_native.sh
@@ -13,7 +13,7 @@ cp ./nCine-external/lib/libglfw.so.3 dfclient-native/
 cp ./nCine-external/lib/libpng16d.so.16 dfclient-native/
 cp ./nCine-external/lib/libwebp.so.7 dfclient-native/
 cp ./nCine-external/lib/liblua5.3.so dfclient-native/
-cp /usr/lib/x86_64-linux-gnu/libboost_system.so.1.65.1 dfclient-native/
+cp /usr/local/lib/libboost_system.so.1.74.0 dfclient-native/
 
 if [ "$1" != "--keep" ]
 then

--- a/env/Dockerfile
+++ b/env/Dockerfile
@@ -7,9 +7,9 @@ RUN apt-get update && apt-get install -y git build-essential clang libbox2d-dev 
     wget https://github.com/Kitware/CMake/releases/download/v3.18.3/cmake-3.18.3-Linux-x86_64.sh && \
     chmod +x cmake-3.18.3-Linux-x86_64.sh && mkdir -p /opt/cmake && \
     ./cmake-3.18.3-Linux-x86_64.sh --skip-license --prefix=/opt/cmake && \
-    ln -s /opt/cmake/bin/cmake /usr/bin/cmake && \
+    ln -s /opt/cmake/bin/cmake /usr/bin/cmake && rm -rf cmake-3.18.3-Linux-x86_64.sh && \
     git clone https://github.com/google/flatbuffers && cd flatbuffers && \
-    mkdir build && cd build && cmake .. && make install -j5 && cd / && \
+    mkdir build && cd build && cmake .. && make install -j5 && cd / && rm -rf flatbuffers && \
     mkdir /emsdk && chmod -R 777 /emsdk && \
     rm -rf /usr/bin/python && ln -s /usr/bin/python3 /usr/bin/python && \
     adduser --disabled-password --gecos "" ubuntu

--- a/env/Dockerfile
+++ b/env/Dockerfile
@@ -1,6 +1,9 @@
 FROM ubuntu:18.04
-RUN apt-get update && apt-get install -y git build-essential clang libboost-dev libboost-system-dev libboost-program-options-dev libbox2d-dev libwebsocketpp-dev libglm-dev wget libz-dev libgl1-mesa-dev libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev python3 libpulse-dev python3-pip && \
-    pip3 install flatbuffers && \
+RUN apt-get update && apt-get install -y git build-essential clang libbox2d-dev libwebsocketpp-dev libglm-dev wget libz-dev libgl1-mesa-dev libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev python3 libpulse-dev python3-pip && \
+    pip3 install flatbuffers && cd / && \
+    wget https://dl.bintray.com/boostorg/release/1.74.0/source/boost_1_74_0.tar.gz && \
+    tar xvf boost_1_74_0.tar.gz && cd boost_1_74_0 && ./bootstrap.sh && \
+    ./b2 --with-system --with-program_options --with-headers install && cd / && rm -rf boost_1_74_0 boost_1_74_0.tar.gz && \
     wget https://github.com/Kitware/CMake/releases/download/v3.18.3/cmake-3.18.3-Linux-x86_64.sh && \
     chmod +x cmake-3.18.3-Linux-x86_64.sh && mkdir -p /opt/cmake && \
     ./cmake-3.18.3-Linux-x86_64.sh --skip-license --prefix=/opt/cmake && \

--- a/env/Dockerfile
+++ b/env/Dockerfile
@@ -1,5 +1,5 @@
 FROM ubuntu:18.04
-RUN apt-get update && apt-get install -y git build-essential clang libbox2d-dev libwebsocketpp-dev libglm-dev wget libz-dev libgl1-mesa-dev libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev python3 libpulse-dev python3-pip && \
+RUN apt-get update && apt-get install -y git build-essential clang libbox2d-dev libglm-dev wget libz-dev libgl1-mesa-dev libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev python3 libpulse-dev python3-pip && \
     pip3 install flatbuffers && cd / && \
     wget https://dl.bintray.com/boostorg/release/1.74.0/source/boost_1_74_0.tar.gz && \
     tar xvf boost_1_74_0.tar.gz && cd boost_1_74_0 && ./bootstrap.sh && \

--- a/env/build-docker.sh
+++ b/env/build-docker.sh
@@ -3,4 +3,3 @@ docker stop deadfish-env
 docker rm deadfish-env
 docker rmi df-dev-env
 docker build --tag df-dev-env .
-

--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -30,12 +30,12 @@ find_package(Box2D REQUIRED)
 
 set(CMAKE_CXX_STANDARD 17)
 
-add_executable(deadfishserver 
-  game_thread.cpp
-  main.cpp
-  mobs.cpp
-  level_loader.cpp
-  deadfish.cpp
+file(GLOB server_SRC
+  "*.cpp"
+)
+
+add_executable(deadfishserver
+  ${server_SRC}
 )
 
 target_link_libraries(deadfishserver

--- a/server/build.sh
+++ b/server/build.sh
@@ -8,6 +8,6 @@ cmake -DCMAKE_BUILD_TYPE=Debug ..
 make -j
 
 cp /usr/lib/x86_64-linux-gnu/libBox2D.so.2.3.0 .
-cp /usr/lib/x86_64-linux-gnu/libboost_system.so.1.65.1 .
-cp /usr/lib/x86_64-linux-gnu/libboost_program_options.so.1.65.1 .
+cp /usr/local/lib/libboost_system.so.1.74.0 .
+cp /usr/local/lib/libboost_program_options.so.1.74.0 .
 cp ../run_server.sh .

--- a/server/deadfish.hpp
+++ b/server/deadfish.hpp
@@ -3,19 +3,18 @@
 #include <string>
 #include <mutex>
 #include <memory>
+#include <iostream>
+#include <thread>
 #include <Box2D/Box2D.h>
-#include <websocketpp/config/asio_no_tls.hpp>
-#include <websocketpp/server.hpp>
 #include <glm/vec2.hpp>
 #include <boost/program_options.hpp>
 #include "../common/deadfish_generated.h"
 #include "../common/constants.hpp"
+#include "websocket.hpp"
 
 namespace boost_po = boost::program_options;
 
 #define UNUSED __attribute__((unused)) 
-
-typedef websocketpp::server<websocketpp::config::asio> server;
 
 std::ostream& operator<<(std::ostream &os, glm::vec2 &v);
 std::ostream& operator<<(std::ostream &os, b2Vec2 v);
@@ -56,6 +55,7 @@ struct Collideable {
 struct Mob : public Collideable {
 	uint16_t mobID = 0;
 	uint16_t species = 0;
+	dfws::Handle wsHandle;
 	b2Body* body = nullptr;
 	MobState state = MobState::WALKING;
 	virtual void handleCollision(UNUSED Collideable& other) override {}
@@ -71,7 +71,6 @@ struct Mob : public Collideable {
 
 struct Player : public Mob {
 	std::string name;
-	websocketpp::connection_hdl conn_hdl;
 	bool ready = false;
 	Mob* killTarget = nullptr;
 	uint16_t attackTimeout = 0;
@@ -185,4 +184,3 @@ public:
 };
 
 extern GameState gameState;
-extern server websocket_server;

--- a/server/deadfish.hpp
+++ b/server/deadfish.hpp
@@ -55,7 +55,6 @@ struct Collideable {
 struct Mob : public Collideable {
 	uint16_t mobID = 0;
 	uint16_t species = 0;
-	dfws::Handle wsHandle;
 	b2Body* body = nullptr;
 	MobState state = MobState::WALKING;
 	virtual void handleCollision(UNUSED Collideable& other) override {}
@@ -73,6 +72,7 @@ struct Player : public Mob {
 	std::string name;
 	bool ready = false;
 	Mob* killTarget = nullptr;
+	dfws::Handle wsHandle;
 	uint16_t attackTimeout = 0;
 	std::chrono::system_clock::time_point lastAttack;
 	int points = 0;

--- a/server/game_thread.cpp
+++ b/server/game_thread.cpp
@@ -208,7 +208,7 @@ flatbuffers::Offset<void> makeWorldState(Player &player, flatbuffers::FlatBuffer
 	std::string hspotname = ""; // name of the hidingspot that the player is in
 	for(auto &hspot : gameState.level->hidingspots) {
 		auto playerInHspot = hspot->playersInside.find(&player);
-		if(playerInHspot != hspot->playersInside.end()) {
+		if (playerInHspot != hspot->playersInside.end()) {
 			hspotname = hspot->name;
 			break;
 		}

--- a/server/game_thread.cpp
+++ b/server/game_thread.cpp
@@ -1,4 +1,3 @@
-#include <iostream>
 #include <limits>
 
 #define GLM_ENABLE_EXPERIMENTAL
@@ -10,11 +9,6 @@
 #include "deadfish.hpp"
 #include "game_thread.hpp"
 #include "level_loader.hpp"
-
-bool operator==(websocketpp::connection_hdl &a, websocketpp::connection_hdl &b)
-{
-	return a.lock().get() == b.lock().get();
-}
 
 uint16_t newMobID()
 {
@@ -53,7 +47,7 @@ std::string makeServerMessage(flatbuffers::FlatBufferBuilder &builder,
 }
 
 
-void sendGameAlreadyInProgress(const websocketpp::connection_hdl& hdl)
+void sendGameAlreadyInProgress(dfws::Handle hdl)
 {
 	std::cout << "sending game already in progress";
 	flatbuffers::FlatBufferBuilder builder;
@@ -61,7 +55,7 @@ void sendGameAlreadyInProgress(const websocketpp::connection_hdl& hdl)
 		FlatBuffGenerated::SimpleServerEventType_GameAlreadyInProgress);
 	auto str = makeServerMessage(builder, FlatBuffGenerated::ServerMessageUnion_SimpleServerEvent,
 		offset.Union());
-	websocket_server.send(hdl, str, websocketpp::frame::opcode::binary);
+	dfws::SendData(hdl, str);
 }
 
 void sendServerMessage(Player &player,
@@ -70,32 +64,23 @@ void sendServerMessage(Player &player,
 					   flatbuffers::Offset<void> offset)
 {
 	auto str = makeServerMessage(builder, type, offset);
-	websocket_server.send(player.conn_hdl, str, websocketpp::frame::opcode::binary);
+	dfws::SendData(player.wsHandle, str);
 }
 
 void sendToAll(std::string &data)
 {
 	for (auto &p : gameState.players)
 	{
-		websocket_server.send(p->conn_hdl, data, websocketpp::frame::opcode::binary);
+		dfws::SendData(p->wsHandle, data);
 	}
 }
 
-void stopAll()
-{
-	websocket_server.stop_perpetual();
-	for (auto& p : gameState.players)
-	{
-		websocket_server.close(p->conn_hdl, websocketpp::close::status::normal, "goodbye");
-	}
-}
-
-Player* getPlayerByConnHdl(websocketpp::connection_hdl &hdl)
+Player* getPlayerByConnHdl(dfws::Handle hdl)
 {
 	auto player = gameState.players.begin();
 	while (player != gameState.players.end())
 	{
-		if ((*player)->conn_hdl == hdl)
+		if ((*player)->wsHandle == hdl)
 		{
 			return player->get();
 		}
@@ -433,9 +418,8 @@ void sendHighscores()
 	sendToAll(data);
 }
 
-void gameOnMessage(websocketpp::connection_hdl hdl, const server::message_ptr& msg)
+void gameOnMessage(dfws::Handle hdl, const std::string& payload)
 {
-	const auto payload = msg->get_payload();
 	const auto clientMessage = flatbuffers::GetRoot<FlatBuffGenerated::ClientMessage>(payload.c_str());
 	const auto guard = gameState.lock();
 

--- a/server/game_thread.hpp
+++ b/server/game_thread.hpp
@@ -2,11 +2,10 @@
 
 void gameThread();
 uint16_t newMobID();
-void gameOnMessage(websocketpp::connection_hdl hdl, const server::message_ptr& msg);
-bool operator==(websocketpp::connection_hdl &a, websocketpp::connection_hdl &b);
+void gameOnMessage(dfws::Handle hdl, const std::string& msg);
 void spawnPlayer(Player& p);
 void spawnCivilian();
-Player* getPlayerByConnHdl(websocketpp::connection_hdl &hdl);
+Player* getPlayerByConnHdl(dfws::Handle hdl);
 void sendServerMessage(Player& player,
 	flatbuffers::FlatBufferBuilder &builder,
 	FlatBuffGenerated::ServerMessageUnion type,
@@ -17,4 +16,4 @@ std::string makeServerMessage(flatbuffers::FlatBufferBuilder &builder,
 bool mobSeePoint(Mob &m, b2Vec2 &point);
 void sendToAll(std::string &data);
 void sendHighscores();
-void sendGameAlreadyInProgress(const websocketpp::connection_hdl& hdl);
+void sendGameAlreadyInProgress(dfws::Handle hdl);

--- a/server/main.cpp
+++ b/server/main.cpp
@@ -52,9 +52,9 @@ void startGame() {
 	new std::thread(gameThread); // leak the shit out of it yooo
 }
 
-void on_message(dfws::Handle hdl, const std::string& payload)
+void mainOnMessage(dfws::Handle hdl, const std::string& payload)
 {
-	std::cout << "on_message\n";
+	std::cout << "mainOnMessage\n";
 	std::cout << "message from " << hdl << "\n";
 
 	const auto clientMessage = flatbuffers::GetRoot<FlatBuffGenerated::ClientMessage>(payload.c_str());
@@ -104,7 +104,7 @@ void on_message(dfws::Handle hdl, const std::string& payload)
 	}
 }
 
-void on_close(dfws::Handle hdl)
+void mainOnClose(dfws::Handle hdl)
 {
 	auto player = gameState.players.begin();
 	while (player != gameState.players.end())
@@ -130,7 +130,7 @@ void on_close(dfws::Handle hdl)
 	}
 }
 
-void on_open(dfws::Handle hdl) {
+void mainOnOpen(dfws::Handle hdl) {
 	if (gameState.phase == GamePhase::GAME) {
 		sendGameAlreadyInProgress(hdl);
 		return;
@@ -181,9 +181,9 @@ int main(int argc, const char* const argv[])
 	if (!handleCliOptions(argc, argv))
 		return 1;
 
-	dfws::SetOnMessage(&on_message);
-	dfws::SetOnOpen(&on_open);
-	dfws::SetOnClose(&on_close);
+	dfws::SetOnMessage(&mainOnMessage);
+	dfws::SetOnOpen(&mainOnOpen);
+	dfws::SetOnClose(&mainOnClose);
 
 	std::cout << "server started\n";
 

--- a/server/main.cpp
+++ b/server/main.cpp
@@ -176,19 +176,20 @@ bool handleCliOptions(int argc, const char* const argv[]) {
 
 int main(int argc, const char* const argv[])
 {
-	srand(time(nullptr));
+	// srand(time(nullptr));
 
-	if (!handleCliOptions(argc, argv))
-		return 1;
+	// if (!handleCliOptions(argc, argv))
+	// 	return 1;
 
-	dfws::Init();
-	dfws::SetOnMessage(&on_message);
-	dfws::SetOnOpen(&on_open);
-	dfws::SetOnClose(&on_close);
+	// dfws::SetOnMessage(&on_message);
+	// dfws::SetOnOpen(&on_open);
+	// dfws::SetOnClose(&on_close);
 
-	std::cout << "server started\n";
+	// std::cout << "server started\n";
 
-	dfws::Run();
+	// int port = gameState.options["port"].as<int>();
+
+	dfws::Run(63987);
 
 	std::cout << "server stopped\n";
 	return 0;

--- a/server/main.cpp
+++ b/server/main.cpp
@@ -57,6 +57,9 @@ void mainOnMessage(dfws::Handle hdl, const std::string& payload)
 	std::cout << "mainOnMessage\n";
 	std::cout << "message from " << hdl << "\n";
 
+	if (payload.size() == 0)
+		return; // wtf
+
 	const auto clientMessage = flatbuffers::GetRoot<FlatBuffGenerated::ClientMessage>(payload.c_str());
 
 	switch (clientMessage->event_type())

--- a/server/main.cpp
+++ b/server/main.cpp
@@ -176,20 +176,20 @@ bool handleCliOptions(int argc, const char* const argv[]) {
 
 int main(int argc, const char* const argv[])
 {
-	// srand(time(nullptr));
+	srand(time(nullptr));
 
-	// if (!handleCliOptions(argc, argv))
-	// 	return 1;
+	if (!handleCliOptions(argc, argv))
+		return 1;
 
-	// dfws::SetOnMessage(&on_message);
-	// dfws::SetOnOpen(&on_open);
-	// dfws::SetOnClose(&on_close);
+	dfws::SetOnMessage(&on_message);
+	dfws::SetOnOpen(&on_open);
+	dfws::SetOnClose(&on_close);
 
-	// std::cout << "server started\n";
+	std::cout << "server started\n";
 
-	// int port = gameState.options["port"].as<int>();
+	int port = gameState.options["port"].as<int>();
 
-	dfws::Run(63987);
+	dfws::Run(port);
 
 	std::cout << "server stopped\n";
 	return 0;

--- a/server/main.cpp
+++ b/server/main.cpp
@@ -54,9 +54,6 @@ void startGame() {
 
 void mainOnMessage(dfws::Handle hdl, const std::string& payload)
 {
-	std::cout << "mainOnMessage\n";
-	std::cout << "message from " << hdl << "\n";
-
 	if (payload.size() == 0)
 		return; // wtf
 

--- a/server/websocket.cpp
+++ b/server/websocket.cpp
@@ -1,0 +1,31 @@
+#include "websocket.hpp"
+
+void dfws::Init()
+{
+
+}
+
+void dfws::SendData(Handle hdl, const std::string& data)
+{
+
+}
+
+void dfws::SetOnMessage(OnMessageHandler msgHandler)
+{
+
+}
+
+void dfws::SetOnOpen(OnOpenHandler handler)
+{
+
+}
+
+void dfws::SetOnClose(OnCloseHandler handler)
+{
+
+}
+
+void dfws::Run()
+{
+
+}

--- a/server/websocket.cpp
+++ b/server/websocket.cpp
@@ -1,9 +1,31 @@
+#include <boost/beast/core.hpp>
+#include <boost/beast/websocket.hpp>
+#include <boost/asio/dispatch.hpp>
+#include <boost/asio/strand.hpp>
+#include <algorithm>
+#include <cstdlib>
+#include <functional>
+#include <iostream>
+#include <memory>
+#include <string>
+#include <thread>
+#include <vector>
+#include <map>
+
+#include <boost/beast/core/buffers_to_string.hpp>
+
+namespace beast = boost::beast;         // from <boost/beast.hpp>
+namespace http = beast::http;           // from <boost/beast/http.hpp>
+namespace websocket = beast::websocket; // from <boost/beast/websocket.hpp>
+namespace net = boost::asio;            // from <boost/asio.hpp>
+
 #include "websocket.hpp"
 
-void dfws::Init()
-{
-
-}
+net::io_context ioc{1};
+tcp::acceptor acceptor_{ioc};
+uint16_t lastSocketID = 0;
+std::map<uint16_t, websocket::stream<beast::tcp_stream>> sockets;
+std::map<uint16_t, beast::flat_buffer> buffers;
 
 void dfws::SendData(Handle hdl, const std::string& data)
 {
@@ -25,7 +47,119 @@ void dfws::SetOnClose(OnCloseHandler handler)
 
 }
 
-void dfws::Run()
+void
+fail(beast::error_code ec, char const* what)
 {
+    std::cerr << what << ": " << ec.message() << "\n";
+}
 
+void dfwsOnRead(uint16_t socketID, beast::error_code ec, std::size_t bytes_transferred)
+{
+    std::cout << "dfwsOnRead\n";
+    auto socketItr = sockets.find(socketID);
+    if (socketItr == sockets.end()) {
+        std::cout << "could not find socket for id " << socketID << "\n";
+        return;
+    }
+    auto bufferItr = buffers.find(socketID);
+    if (bufferItr == buffers.end()) {
+        std::cout << "could not find buffer for id " << socketID << "\n";
+        return;
+    }
+    auto& ws = socketItr->second;
+    auto& buffer = bufferItr->second;
+    ws.async_read(buffer, std::bind(&dfwsOnRead, socketID, std::placeholders::_1, std::placeholders::_2));
+}
+
+void dfwsSocketOnAccept(uint16_t socketID, beast::error_code ec)
+{
+    std::cout << "socket on accept " << socketID << "\n";
+    auto socketItr = sockets.find(socketID);
+    if (socketItr == sockets.end()) {
+        std::cout << "could not find socket for id " << socketID << "\n";
+        return;
+    }
+    auto bufferItr = buffers.find(socketID);
+    if (bufferItr == buffers.end()) {
+        std::cout << "could not find buffer for id " << socketID << "\n";
+        return;
+    }
+    auto& ws = socketItr->second;
+    auto& buffer = bufferItr->second;
+    ws.async_read(buffer, std::bind(&dfwsOnRead, socketID, std::placeholders::_1, std::placeholders::_2));
+}
+
+void dfwsOnAccept(beast::error_code ec, tcp::socket socket)
+{
+    std::cout << "on accept\n";
+    // websocket::stream<beast::tcp_stream> ws_(std::move(socket));
+    uint16_t currentID = lastSocketID++;
+    sockets.emplace(std::make_pair(currentID, websocket::stream<beast::tcp_stream>(std::move(socket))));
+    buffers.emplace(std::make_pair(currentID, beast::flat_buffer{}));
+    auto itr = sockets.find(currentID);
+    auto& ws_ = itr->second;
+
+    ws_.binary(true);
+
+    // Set suggested timeout settings for the websocket
+    ws_.set_option(
+        websocket::stream_base::timeout::suggested(
+            beast::role_type::server));
+
+    // Set a decorator to change the Server of the handshake
+    ws_.set_option(websocket::stream_base::decorator(
+        [](websocket::response_type& res)
+        {
+            res.set(http::field::server,
+                std::string(BOOST_BEAST_VERSION_STRING) +
+                    " websocket-server-async");
+        }));
+    // Accept the websocket handshake
+    ws_.async_accept(std::bind(&dfwsSocketOnAccept, currentID, std::placeholders::_1));
+
+    // accept another connection
+    acceptor_.async_accept(&dfwsOnAccept);
+}
+
+void dfws::Run(unsigned short port)
+{
+    auto const address = net::ip::make_address("0.0.0.0");
+    beast::error_code ec;
+    tcp::endpoint endpoint{address, port};
+
+    // Open the acceptor
+    acceptor_.open(endpoint.protocol(), ec);
+    if(ec)
+    {
+        fail(ec, "open");
+        return;
+    }
+
+    // Allow address reuse
+    acceptor_.set_option(net::socket_base::reuse_address(true), ec);
+    if(ec)
+    {
+        fail(ec, "set_option");
+        return;
+    }
+
+    // Bind to the server address
+    acceptor_.bind(endpoint, ec);
+    if(ec)
+    {
+        fail(ec, "bind");
+        return;
+    }
+
+    // Start listening for connections
+    acceptor_.listen(
+        net::socket_base::max_listen_connections, ec);
+    if(ec)
+    {
+        fail(ec, "listen");
+        return;
+    }
+
+    acceptor_.async_accept(&dfwsOnAccept);
+    ioc.run();
 }

--- a/server/websocket.hpp
+++ b/server/websocket.hpp
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <string>
+
+namespace dfws {
+
+typedef int Handle;
+
+typedef void (*OnMessageHandler) (Handle hdl, const std::string& msg);
+typedef void (*OnOpenHandler) (Handle hdl);
+typedef void (*OnCloseHandler) (Handle hdl);
+
+void Init();
+void SendData(Handle hdl, const std::string& data);
+void SetOnMessage(OnMessageHandler msgHandler);
+void SetOnOpen(OnOpenHandler handler);
+void SetOnClose(OnCloseHandler handler);
+void Run();
+
+};

--- a/server/websocket.hpp
+++ b/server/websocket.hpp
@@ -2,6 +2,10 @@
 
 #include <string>
 
+#include <boost/asio/ip/tcp.hpp>
+
+using tcp = boost::asio::ip::tcp;       // from <boost/asio/ip/tcp.hpp>
+
 namespace dfws {
 
 typedef int Handle;
@@ -10,11 +14,10 @@ typedef void (*OnMessageHandler) (Handle hdl, const std::string& msg);
 typedef void (*OnOpenHandler) (Handle hdl);
 typedef void (*OnCloseHandler) (Handle hdl);
 
-void Init();
 void SendData(Handle hdl, const std::string& data);
 void SetOnMessage(OnMessageHandler msgHandler);
 void SetOnOpen(OnOpenHandler handler);
 void SetOnClose(OnCloseHandler handler);
-void Run();
+void Run(unsigned short port);
 
 };


### PR DESCRIPTION
This PR upgrades the used Boost library from 1.65.1 to 1.74.0 (as the former doesn't include the Beast library) and changes the used websocket engine from websocketpp (that depends on the old version of boost) to the boost::beast library. This is to:
1. not rely on old version of boost (websocketpp doesn't work with any newer versions)
2. upgrade the boost library overall
3. possibly enable a windows build in the future (the package manager that I use only has the new boost in it)
4. introduce more problems that are inevitably going to arise along with all the boost black magic fuckery
5. i just kinda wanted to do it

Please be gentle, this is my first PR.

Please note that the build system has changed. You will have to download (or build) a new docker image.