### PR TITLE
hidingspot fix (reset on player death inside)

### DIFF
--- a/server/mobs.cpp
+++ b/server/mobs.cpp
@@ -71,6 +71,9 @@ void Mob::update()
 void Player::reset()
 {
 	gameState.b2world->DestroyBody(this->body);
+	for(auto& hspot : gameState.level->hidingspots) {
+		hspot->playersInside.erase(this);
+	}
 	this->killTarget = nullptr;
 	this->toBeDeleted = false;
 	this->state = MobState::WALKING;


### PR DESCRIPTION
Fixed the bug occuring when a player got killed in the bushes and the bushes stayed transparent and all the other bushes were not.