### PR TITLE
Blink + minor refactors

### DIFF
--- a/client/dfclient/src/gameplay_state.cpp
+++ b/client/dfclient/src/gameplay_state.cpp
@@ -654,7 +654,7 @@ void GameplayState::TryUseSkill(uint8_t skillPos) {
 	const float screenHeight = ncine::theApplication().height();
 	auto &mouseState = ncine::theApplication().inputManager().mouseState();
 	const float serverX = (this->mySprite->position().x + (mouseState.x - screenWidth / 2) * 1.5f) * PIXELS2METERS;
-	const float serverY = -(this->mySprite->position().y + (mouseState.y - screenHeight / 2) * 1.5f) * PIXELS2METERS;
+	const float serverY = -(this->mySprite->position().y - (mouseState.y - screenHeight / 2) * 1.5f) * PIXELS2METERS;
 	flatbuffers::FlatBufferBuilder builder;
 	FlatBuffGenerated::Vec2 mousePos{serverX, serverY};
 	auto cmdSkill = FlatBuffGenerated::CreateCommandSkill(builder, skillPos, &mousePos);

--- a/common/constants.hpp
+++ b/common/constants.hpp
@@ -38,3 +38,4 @@ enum class Skills {
 };
 
 const int MAX_SKILLS = 3;
+const float BLINK_RANGE = 10.f;

--- a/server/deadfish.hpp
+++ b/server/deadfish.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include <unordered_map>
+#include <map>
 #include <string>
 #include <mutex>
 #include <memory>
@@ -219,7 +220,7 @@ public:
 
 	std::unique_ptr<b2World> b2world = nullptr;
 	std::vector<std::unique_ptr<Player>> players;
-	std::vector<std::unique_ptr<Civilian>> civilians;
+	std::map<uint16_t, std::unique_ptr<Civilian>> civilians;
 	std::vector<std::unique_ptr<InkParticle>> inkParticles;
 
 	inline std::unique_ptr<std::lock_guard<std::mutex>> lock() {

--- a/server/deadfish.hpp
+++ b/server/deadfish.hpp
@@ -87,7 +87,7 @@ struct InkParticle :
 	uint16_t inkID;
 	uint16_t lifetimeFrames;
 
-	InkParticle(b2Body* b, Player& owner);
+	InkParticle(b2Body* b);
 
 	void handleCollision(Collideable& other) override;
 	void endCollision(Collideable& other) override;

--- a/server/game_thread.cpp
+++ b/server/game_thread.cpp
@@ -445,10 +445,11 @@ void executeSkill(Player& p, uint8_t skillPos, b2Vec2 mousePos) {
 	if (skillHandler == nullptr) {
 		std::cout << "no such skill handler " << (uint16_t) skill << "\n";
 	}
-	skillHandler(p, skill, mousePos);
-	std::cout << "skills size " << p.skills.size() << "\n";
-	p.skills.erase(p.skills.begin() + skillPos);
-	p.sendSkillBarUpdate();
+	bool used = skillHandler(p, skill, mousePos);
+	if (used) {
+		p.skills.erase(p.skills.begin() + skillPos);
+		p.sendSkillBarUpdate();
+	}
 }
 
 void gameOnMessage(dfws::Handle hdl, const std::string& payload)

--- a/server/game_thread.hpp
+++ b/server/game_thread.hpp
@@ -18,3 +18,4 @@ bool mobSeePoint(Mob &m, b2Vec2 &point);
 void sendToAll(std::string &data);
 void sendHighscores();
 void sendGameAlreadyInProgress(dfws::Handle hdl);
+void physicsInitMob(Mob *m, glm::vec2 pos, float angle, float radius, uint16 categoryBits);

--- a/server/mobs.cpp
+++ b/server/mobs.cpp
@@ -265,7 +265,7 @@ Mob::~Mob()
 void handleGoldfishKill(Player& killer) {
 	if (killer.skills.size() == MAX_SKILLS)
 		return;
-	uint16_t skill = (int) Skills::INK_BOMB; // all skills are ink bombs bc it's the only working skill for now
+	uint16_t skill = (uint16_t) (rand() % 2 == 0 ? Skills::INK_BOMB : Skills::BLINK);
 	killer.skills.push_back(skill);
 	killer.sendSkillBarUpdate();
 }
@@ -284,7 +284,6 @@ void Civilian::handleKill(Player& killer) {
 	flatbuffers::FlatBufferBuilder builder;
 	auto ev = FlatBuffGenerated::CreateDeathReport(builder, killer.playerID, -1);
 	sendServerMessage(killer, builder, FlatBuffGenerated::ServerMessageUnion_DeathReport, ev.Union());
-	std::cout << "sent a death report\n";
 
 	sendHighscores();
 }

--- a/server/skills.cpp
+++ b/server/skills.cpp
@@ -1,4 +1,5 @@
 #include "skills.hpp"
+#include "game_thread.hpp"
 #include "../common/geometry.hpp"
 
 uint16_t lastInkID = 0;
@@ -12,7 +13,7 @@ void launchInkParticle(Player& p, b2Vec2 direction) {
 	b2CircleShape circleShape;
 	circleShape.m_radius = 0.6f;
 
-	auto inkPart = std::make_unique<InkParticle>(inkBody, p);
+	auto inkPart = std::make_unique<InkParticle>(inkBody);
 
 	b2FixtureDef fixtureDef;
 	fixtureDef.shape = &circleShape;
@@ -36,19 +37,20 @@ const float INK_INIT_SPEED_VARIABLE = 1.5;
 const int INK_COUNT = 5;
 const int INK_LIFETIME_FRAMES = 80; // 4s
 
-void executeSkillInkbomb(Player& p, UNUSED Skills skill, b2Vec2 mousePos) {
+bool executeSkillInkbomb(Player& p, UNUSED Skills skill, b2Vec2 mousePos) {
 	std::cout << "ink bomb\n";
 	b2Vec2 mouseVector = mousePos - p.body->GetPosition();
-	float mouseAngleDeg = -angleFromVector(mouseVector) * TO_DEGREES;
+	float mouseAngleDeg = angleFromVector(mouseVector) * TO_DEGREES;
 	for (int i = 0; i < INK_COUNT; i++) {
 		float mouseAngleRandomized = mouseAngleDeg + rand() % 90 - 45;
 		b2Vec2 direction(INK_INIT_SPEED_BASE + (rand() % ((int)(INK_INIT_SPEED_VARIABLE * 10)))/10.f, 0);
 		direction = rotateVector(direction, mouseAngleRandomized * TO_RADIANS);
 		launchInkParticle(p, direction);
 	}
+	return true;
 }
 
-InkParticle::InkParticle(b2Body* b, Player& o) 
+InkParticle::InkParticle(b2Body* b)
 {
 	this->body = b;
 	this->lifetimeFrames = INK_LIFETIME_FRAMES;
@@ -98,10 +100,15 @@ bool InkParticle::obstructsSight(UNUSED Player* p) {
 	return true;
 }
 
-void executeSkillMobManipulator(UNUSED Player& p, UNUSED Skills skill, UNUSED b2Vec2 mousePos) {
+bool executeSkillMobManipulator(UNUSED Player& p, UNUSED Skills skill, UNUSED b2Vec2 mousePos) {
 	std::cout << "mob manipulator " << (uint16_t) skill << "\n";
+	return true;
 }
 
-void executeSkillBlink(UNUSED Player& p, UNUSED Skills skill, UNUSED b2Vec2 mousePos) {
-	std::cout << "skill blink\n";
+bool executeSkillBlink(Player& p, UNUSED Skills skill, b2Vec2 mousePos) {
+	if (b2Distance(mousePos, p.body->GetPosition()) > BLINK_RANGE)
+		return false; // ignore blinks out of range
+	gameState.b2world->DestroyBody(p.body);
+	physicsInitMob(&p, b2g(mousePos), 0, 0.3f, 3);
+	return true;
 }

--- a/server/skills.hpp
+++ b/server/skills.hpp
@@ -2,12 +2,13 @@
 
 #include "deadfish.hpp"
 
+// skill handlers return a bool value whether the skill has been used or not
 // apparently this is correct cpp syntax
-using skillHandler_t = void (*)(Player& p, Skills skill, b2Vec2 mousePos);
+using skillHandler_t = bool (*)(Player& p, Skills skill, b2Vec2 mousePos);
 
-void executeSkillInkbomb(Player& p, Skills skill, b2Vec2 mousePos);
-void executeSkillMobManipulator(Player& p, Skills skill, b2Vec2 mousePos);
-void executeSkillBlink(Player& p, Skills skill, b2Vec2 mousePos);
+bool executeSkillInkbomb(Player& p, Skills skill, b2Vec2 mousePos);
+bool executeSkillMobManipulator(Player& p, Skills skill, b2Vec2 mousePos);
+bool executeSkillBlink(Player& p, Skills skill, b2Vec2 mousePos);
 
 static skillHandler_t skillHandlers[(uint16_t) Skills::SKILLS_MAX] = {
 	[(uint16_t) Skills::INK_BOMB] = &executeSkillInkbomb,


### PR DESCRIPTION
The blink skill itself turned out to be just 4 lines of code. However while playing and debugging I also discovered other issues. Things that are in this PR:

- blink skill
- a fix in the client: mouse coordinates were sent wrongly on skill activate
- removed owner of the ink bomb, changed mechanics to be more fair to all players
- changed storing civilians on the server from a vector to a map to achieve stable iterators and avoid segfaults in specific edge cases