### PR TITLE
Client matchmaking

### DIFF
--- a/client/dfclient/CMakeLists.txt
+++ b/client/dfclient/CMakeLists.txt
@@ -84,6 +84,7 @@ if(EMSCRIPTEN)
 		file(COPY ${PACKAGE_DATA_DIR}/icons/icon.ico DESTINATION ${CMAKE_BINARY_DIR})
 		file(RENAME ${CMAKE_BINARY_DIR}/icon.ico ${CMAKE_BINARY_DIR}/favicon.ico)
 	endif()
+	include_directories("/usr/local/include")  # for boost ptree
 else()
 	set(THREADS_PREFER_PTHREAD_FLAG ON)
 	find_package(Threads REQUIRED)

--- a/client/dfclient/deadfish.ini.example
+++ b/client/dfclient/deadfish.ini.example
@@ -1,0 +1,6 @@
+[default]
+client_mode=matchmaker
+matchmaker_address=localhost
+matchmaker_port=8000
+direct_address=localhost
+direct_port=63987

--- a/client/dfclient/include/http_client.hpp
+++ b/client/dfclient/include/http_client.hpp
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <string>
+
+// TODO: support both wasm and native builds
+
+namespace http {
+
+/**
+ * Returns a http code if succeeded, otherwise -1
+ * */
+int MatchmakerGet(std::string& ret);
+
+};

--- a/client/dfclient/include/http_client.hpp
+++ b/client/dfclient/include/http_client.hpp
@@ -9,6 +9,6 @@ namespace http {
 /**
  * Returns a http code if succeeded, otherwise -1
  * */
-int MatchmakerGet(std::string& ret);
+int MatchmakerGet(std::string address, std::string port, std::string& ret);
 
 };

--- a/client/dfclient/include/menu_state.hpp
+++ b/client/dfclient/include/menu_state.hpp
@@ -18,6 +18,7 @@ public:
 private:
 	bool TryConnect();
 	void ProcessMatchmakerData(std::string data);
+	void ShowMessage(std::string message);
 
 	Resources& _resources;
 };

--- a/client/dfclient/include/menu_state.hpp
+++ b/client/dfclient/include/menu_state.hpp
@@ -6,6 +6,10 @@
 
 class Resources;
 
+enum class ClientMode {
+	Matchmaker,
+	DirectConnect
+};
 struct MenuState
 	: public GameState
 {
@@ -19,6 +23,14 @@ private:
 	bool TryConnect();
 	void ProcessMatchmakerData(std::string data);
 	void ShowMessage(std::string message);
+	void MatchmakerLayout(char* buf);
+	void DirectConnectLayout(char* buf0, char* buf1);
+
+	ClientMode clientMode = ClientMode::Matchmaker;
+	std::string matchmakerAddress = "localhost";
+	std::string matchmakerPort = "8000";
+	std::string directAddress = "localhost";
+	std::string directPort = "63987";
 
 	Resources& _resources;
 };

--- a/client/dfclient/include/menu_state.hpp
+++ b/client/dfclient/include/menu_state.hpp
@@ -32,8 +32,8 @@ private:
 	std::string directAddress = "localhost";
 	std::string directPort = "63987";
 
-	char buf0[64];
-	char buf1[64];
+	char buf0[64] = {0};
+	char buf1[64] = {0};
 
 	Resources& _resources;
 };

--- a/client/dfclient/include/menu_state.hpp
+++ b/client/dfclient/include/menu_state.hpp
@@ -20,17 +20,20 @@ public:
 	StateType Update(Messages) override;
 
 private:
-	bool TryConnect();
+	void TryConnect();
 	void ProcessMatchmakerData(std::string data);
 	void ShowMessage(std::string message);
-	void MatchmakerLayout(char* buf);
-	void DirectConnectLayout(char* buf0, char* buf1);
+	void MatchmakerLayout();
+	void DirectConnectLayout();
 
 	ClientMode clientMode = ClientMode::Matchmaker;
 	std::string matchmakerAddress = "localhost";
 	std::string matchmakerPort = "8000";
 	std::string directAddress = "localhost";
 	std::string directPort = "63987";
+
+	char buf0[64];
+	char buf1[64];
 
 	Resources& _resources;
 };

--- a/client/dfclient/include/menu_state.hpp
+++ b/client/dfclient/include/menu_state.hpp
@@ -17,6 +17,7 @@ public:
 
 private:
 	bool TryConnect();
+	void ProcessMatchmakerData(std::string data);
 
 	Resources& _resources;
 };

--- a/client/dfclient/include/menu_state.hpp
+++ b/client/dfclient/include/menu_state.hpp
@@ -32,8 +32,8 @@ private:
 	std::string directAddress = "localhost";
 	std::string directPort = "63987";
 
-	char buf0[64] = {0};
-	char buf1[64] = {0};
+	char nicknameBuffer[64] = {0};
+	char serverAddressBuffer[64] = {0};
 
 	Resources& _resources;
 };

--- a/client/dfclient/src/http_client.cpp
+++ b/client/dfclient/src/http_client.cpp
@@ -1,0 +1,77 @@
+#include "http_client.hpp"
+
+const char* MATCHMAKER_ADDRESS = "localhost";
+const char* MATCHMAKER_PORT = "8000";
+
+#ifdef __EMSCRIPTEN__
+// TODO: write an emscripten version
+int http::MatchmakerGet(std::string& ret)
+{
+    return -1;
+}
+#else // __EMSCRIPTEN__
+
+#include <boost/beast/core.hpp>
+#include <boost/beast/http.hpp>
+#include <boost/beast/version.hpp>
+#include <boost/asio/connect.hpp>
+#include <boost/asio/ip/tcp.hpp>
+#include <cstdlib>
+#include <iostream>
+#include <string>
+
+namespace beast = boost::beast;     // from <boost/beast.hpp>
+namespace bhttp = beast::http;      // from <boost/beast/http.hpp>
+namespace net = boost::asio;        // from <boost/asio.hpp>
+using tcp = net::ip::tcp;           // from <boost/asio/ip/tcp.hpp>
+
+int http::MatchmakerGet(std::string& ret)
+{
+    // The io_context is required for all I/O
+    net::io_context ioc;
+
+    // These objects perform our I/O
+    tcp::resolver resolver(ioc);
+    beast::tcp_stream stream(ioc);
+
+    // Look up the domain name
+    auto const results = resolver.resolve(MATCHMAKER_ADDRESS, MATCHMAKER_PORT);
+
+    // Make the connection on the IP address we get from a lookup
+    stream.connect(results);
+
+    // Set up an HTTP GET request message
+    bhttp::request<bhttp::string_body> req{bhttp::verb::get, "/matchmake", 10};
+    req.set(bhttp::field::host, MATCHMAKER_ADDRESS);
+    req.set(bhttp::field::user_agent, BOOST_BEAST_VERSION_STRING);
+
+    // Send the HTTP request to the remote host
+    bhttp::write(stream, req);
+
+    // This buffer is used for reading and must be persisted
+    beast::flat_buffer buffer;
+
+    // Declare a container to hold the response
+    bhttp::response<bhttp::dynamic_body> res;
+
+    // Receive the HTTP response
+    bhttp::read(stream, buffer, res);
+
+    // Gracefully close the socket
+    beast::error_code ec;
+    stream.socket().shutdown(tcp::socket::shutdown_both, ec);
+
+    // not_connected happens sometimes
+    // so don't bother reporting it.
+    //
+    if(ec) {
+        std::cout << "socket failed, ec: " << ec << "\n";
+        return -1;
+    }
+
+    ret = beast::buffers_to_string(res.body().data());
+
+    return res.result_int();
+}
+
+#endif // __EMSCRIPTEN__

--- a/client/dfclient/src/http_client.cpp
+++ b/client/dfclient/src/http_client.cpp
@@ -1,8 +1,10 @@
 #include "http_client.hpp"
 
+#include <exception>
+
 #ifdef __EMSCRIPTEN__
 // TODO: write an emscripten version
-int http::MatchmakerGet(std::string& ret)
+int http::MatchmakerGet(std::string address, std::string port, std::string& ret)
 {
 	return -1;
 }
@@ -45,7 +47,7 @@ static int throwingMatchmakerGet(std::string address, std::string port, std::str
 	// Send the HTTP request to the remote host
 	bhttp::write(stream, req);
 
-	// This buffer is used for reading and must be persisted
+	// This buffer is used for reading
 	beast::flat_buffer buffer;
 
 	// Declare a container to hold the response
@@ -73,7 +75,8 @@ int http::MatchmakerGet(std::string address, std::string port, std::string& ret)
 	int retCode = 0;
 	try {
 		retCode = throwingMatchmakerGet(address, port, ret);
-	} catch (...) {
+	} catch (std::exception& e) {
+		std::cout << "failed to connect to matchmaker: " << e.what() << "\n";
 		return -1;
 	}
 	return retCode;

--- a/client/dfclient/src/http_client.cpp
+++ b/client/dfclient/src/http_client.cpp
@@ -1,8 +1,5 @@
 #include "http_client.hpp"
 
-const char* MATCHMAKER_ADDRESS = "localhost";
-const char* MATCHMAKER_PORT = "8000";
-
 #ifdef __EMSCRIPTEN__
 // TODO: write an emscripten version
 int http::MatchmakerGet(std::string& ret)
@@ -25,7 +22,7 @@ namespace bhttp = beast::http;      // from <boost/beast/http.hpp>
 namespace net = boost::asio;        // from <boost/asio.hpp>
 using tcp = net::ip::tcp;           // from <boost/asio/ip/tcp.hpp>
 
-static int throwingMatchmakerGet(std::string& ret)
+static int throwingMatchmakerGet(std::string address, std::string port, std::string& ret)
 {
 	// The io_context is required for all I/O
 	net::io_context ioc;
@@ -35,14 +32,14 @@ static int throwingMatchmakerGet(std::string& ret)
 	beast::tcp_stream stream(ioc);
 
 	// Look up the domain name
-	auto const results = resolver.resolve(MATCHMAKER_ADDRESS, MATCHMAKER_PORT);
+	auto const results = resolver.resolve(address, port);
 
 	// Make the connection on the IP address we get from a lookup
 	stream.connect(results);
 
 	// Set up an HTTP GET request message
 	bhttp::request<bhttp::string_body> req{bhttp::verb::get, "/matchmake", 10};
-	req.set(bhttp::field::host, MATCHMAKER_ADDRESS);
+	req.set(bhttp::field::host, address);
 	req.set(bhttp::field::user_agent, BOOST_BEAST_VERSION_STRING);
 
 	// Send the HTTP request to the remote host
@@ -74,11 +71,11 @@ static int throwingMatchmakerGet(std::string& ret)
 	return res.result_int();
 }
 
-int http::MatchmakerGet(std::string& ret)
+int http::MatchmakerGet(std::string address, std::string port, std::string& ret)
 {
 	int retCode = 0;
 	try {
-		retCode = throwingMatchmakerGet(ret);
+		retCode = throwingMatchmakerGet(address, port, ret);
 	} catch (...) {
 		return -1;
 	}

--- a/client/dfclient/src/http_client.cpp
+++ b/client/dfclient/src/http_client.cpp
@@ -58,9 +58,6 @@ static int throwingMatchmakerGet(std::string address, std::string port, std::str
 	beast::error_code ec;
 	stream.socket().shutdown(tcp::socket::shutdown_both, ec);
 
-	// not_connected happens sometimes
-	// so don't bother reporting it.
-	//
 	if(ec) {
 		std::cout << "socket failed, ec: " << ec << "\n";
 		return -1;

--- a/client/dfclient/src/http_client.cpp
+++ b/client/dfclient/src/http_client.cpp
@@ -7,7 +7,7 @@ const char* MATCHMAKER_PORT = "8000";
 // TODO: write an emscripten version
 int http::MatchmakerGet(std::string& ret)
 {
-    return -1;
+	return -1;
 }
 #else // __EMSCRIPTEN__
 
@@ -25,53 +25,64 @@ namespace bhttp = beast::http;      // from <boost/beast/http.hpp>
 namespace net = boost::asio;        // from <boost/asio.hpp>
 using tcp = net::ip::tcp;           // from <boost/asio/ip/tcp.hpp>
 
+static int throwingMatchmakerGet(std::string& ret)
+{
+	// The io_context is required for all I/O
+	net::io_context ioc;
+
+	// These objects perform our I/O
+	tcp::resolver resolver(ioc);
+	beast::tcp_stream stream(ioc);
+
+	// Look up the domain name
+	auto const results = resolver.resolve(MATCHMAKER_ADDRESS, MATCHMAKER_PORT);
+
+	// Make the connection on the IP address we get from a lookup
+	stream.connect(results);
+
+	// Set up an HTTP GET request message
+	bhttp::request<bhttp::string_body> req{bhttp::verb::get, "/matchmake", 10};
+	req.set(bhttp::field::host, MATCHMAKER_ADDRESS);
+	req.set(bhttp::field::user_agent, BOOST_BEAST_VERSION_STRING);
+
+	// Send the HTTP request to the remote host
+	bhttp::write(stream, req);
+
+	// This buffer is used for reading and must be persisted
+	beast::flat_buffer buffer;
+
+	// Declare a container to hold the response
+	bhttp::response<bhttp::dynamic_body> res;
+
+	// Receive the HTTP response
+	bhttp::read(stream, buffer, res);
+
+	// Gracefully close the socket
+	beast::error_code ec;
+	stream.socket().shutdown(tcp::socket::shutdown_both, ec);
+
+	// not_connected happens sometimes
+	// so don't bother reporting it.
+	//
+	if(ec) {
+		std::cout << "socket failed, ec: " << ec << "\n";
+		return -1;
+	}
+
+	ret = beast::buffers_to_string(res.body().data());
+
+	return res.result_int();
+}
+
 int http::MatchmakerGet(std::string& ret)
 {
-    // The io_context is required for all I/O
-    net::io_context ioc;
-
-    // These objects perform our I/O
-    tcp::resolver resolver(ioc);
-    beast::tcp_stream stream(ioc);
-
-    // Look up the domain name
-    auto const results = resolver.resolve(MATCHMAKER_ADDRESS, MATCHMAKER_PORT);
-
-    // Make the connection on the IP address we get from a lookup
-    stream.connect(results);
-
-    // Set up an HTTP GET request message
-    bhttp::request<bhttp::string_body> req{bhttp::verb::get, "/matchmake", 10};
-    req.set(bhttp::field::host, MATCHMAKER_ADDRESS);
-    req.set(bhttp::field::user_agent, BOOST_BEAST_VERSION_STRING);
-
-    // Send the HTTP request to the remote host
-    bhttp::write(stream, req);
-
-    // This buffer is used for reading and must be persisted
-    beast::flat_buffer buffer;
-
-    // Declare a container to hold the response
-    bhttp::response<bhttp::dynamic_body> res;
-
-    // Receive the HTTP response
-    bhttp::read(stream, buffer, res);
-
-    // Gracefully close the socket
-    beast::error_code ec;
-    stream.socket().shutdown(tcp::socket::shutdown_both, ec);
-
-    // not_connected happens sometimes
-    // so don't bother reporting it.
-    //
-    if(ec) {
-        std::cout << "socket failed, ec: " << ec << "\n";
-        return -1;
-    }
-
-    ret = beast::buffers_to_string(res.body().data());
-
-    return res.result_int();
+	int retCode = 0;
+	try {
+		retCode = throwingMatchmakerGet(ret);
+	} catch (...) {
+		return -1;
+	}
+	return retCode;
 }
 
 #endif // __EMSCRIPTEN__

--- a/client/dfclient/src/menu_state.cpp
+++ b/client/dfclient/src/menu_state.cpp
@@ -105,7 +105,7 @@ void MenuState::MatchmakerLayout() {
 	ImGui::InputText("nickname", this->buf0, 64);
 	if (ImGui::Button("find game", {300, 30})) {
 		ImGui::End();
-		gameData.myNickname = std::string(this->buf1);
+		gameData.myNickname = std::string(this->buf0);
 		if (gameData.myNickname.empty()) {
 			this->ShowMessage("enter a nickname");
 			return;

--- a/client/dfclient/src/menu_state.cpp
+++ b/client/dfclient/src/menu_state.cpp
@@ -34,7 +34,19 @@ void MenuState::ShowMessage(std::string message)
 	text->setPosition(res.x * 0.5f, res.y * 0.30f);
 	text->setScale(0.5f);
 	text->setColor(0, 0, 0, 255);
-	_resources._tweens.push_back(CreateTextTween(text));
+	auto tween = tweeny::from(255)
+		.to(255).during(60)
+		.to(0).during(60).onStep(
+		[text] (tweeny::tween<int>& t, int v) -> bool {
+			auto textColor = text->color();
+			text->setColor(textColor.r(), textColor.g(), textColor.b(), v);
+			std::cout << "v " << v << "\n";
+			if (v == 0)
+				delete text;
+			return false;
+		}
+	);
+	_resources._tweens.push_back(tween);
 }
 
 MenuState::MenuState(Resources& r) : _resources(r) {
@@ -68,7 +80,7 @@ MenuState::MenuState(Resources& r) : _resources(r) {
 	}
 	if (this->clientMode == ClientMode::DirectConnect) {
 		auto addr = this->directAddress + ":" + this->directPort;
-		strcpy(this->buf0, addr.c_str());
+		strcpy(this->serverAddressBuffer, addr.c_str());
 	}
 }
 
@@ -102,10 +114,10 @@ void MenuState::ProcessMatchmakerData(std::string data) {
 }
 
 void MenuState::MatchmakerLayout() {
-	ImGui::InputText("nickname", this->buf0, 64);
+	ImGui::InputText("nickname", this->nicknameBuffer, 64);
 	if (ImGui::Button("find game", {300, 30})) {
 		ImGui::End();
-		gameData.myNickname = std::string(this->buf0);
+		gameData.myNickname = std::string(this->nicknameBuffer);
 		if (gameData.myNickname.empty()) {
 			this->ShowMessage("enter a nickname");
 			return;
@@ -123,11 +135,11 @@ void MenuState::MatchmakerLayout() {
 }
 
 void MenuState::DirectConnectLayout() {
-	ImGui::InputText("server", this->buf0, 64);
-	ImGui::InputText("nickname", this->buf1, 64);
+	ImGui::InputText("server", this->serverAddressBuffer, 64);
+	ImGui::InputText("nickname", this->nicknameBuffer, 64);
 	if (ImGui::Button("connect", {300, 30})) {
-		gameData.serverAddress = std::string(this->buf0);
-		gameData.myNickname = std::string(this->buf1);
+		gameData.serverAddress = std::string(this->serverAddressBuffer);
+		gameData.myNickname = std::string(this->nicknameBuffer);
 		TryConnect();
 	}
 	ImGui::End();

--- a/client/dfclient/src/menu_state.cpp
+++ b/client/dfclient/src/menu_state.cpp
@@ -24,6 +24,18 @@ namespace nc = ncine;
 nctl::UniquePtr<nc::Sprite> logoSprite;
 nc::Colorf bgColor(0.96875f, 0.97265625, 0.953125, 1.0f);
 
+void MenuState::ShowMessage(std::string message)
+{
+	nc::SceneNode &rootNode = nc::theApplication().rootNode();
+	auto res = nc::theApplication().appConfiguration().resolution;
+	auto text = new ncine::TextNode(&rootNode, _resources.fonts["comic"].get());
+	text->setString(message.c_str());
+	text->setPosition(res.x * 0.5f, res.y * 0.30f);
+	text->setScale(0.5f);
+	text->setColor(0, 0, 0, 255);
+	_resources._tweens.push_back(CreateTextTween(text));
+}
+
 MenuState::MenuState(Resources& r) : _resources(r) {
 	nc::SceneNode &rootNode = nc::theApplication().rootNode();
 	auto res = nc::theApplication().appConfiguration().resolution;
@@ -31,12 +43,7 @@ MenuState::MenuState(Resources& r) : _resources(r) {
 	nc::theApplication().gfxDevice().setClearColor(bgColor);
 	if (gameData.gameInProgress) {
 		std::cout << "menu game in progress\n";
-		auto text = new ncine::TextNode(&rootNode, _resources.fonts["comic"].get());
-		text->setString("game already in progress");
-		text->setPosition(res.x * 0.5f, res.y * 0.75f);
-		text->setScale(2.0f);
-		text->setColor(0, 0, 0, 255);
-		_resources._tweens.push_back(CreateTextTween(text));
+		ShowMessage("game already in progress");
 		gameData.gameInProgress = false;
 	}
 }
@@ -81,14 +88,21 @@ StateType MenuState::Update(Messages m) {
 	static char buf[64] = "";
 	ImGui::InputText("nickname", buf, 64);
 	if (ImGui::Button("find game", {300, 30})) {
+		ImGui::End();
 		gameData.myNickname = std::string(buf);
+		if (gameData.myNickname.empty()) {
+			this->ShowMessage("enter a nickname");
+			return StateType::Menu;
+		}
 		std::string matchmakerData;
 		int ret = http::MatchmakerGet(matchmakerData);
+		if (ret < 0)
+			this->ShowMessage("couldn't connect to the matchmaker");
 		std::cout << "ret " << ret << "\n";
 		if (ret > 0)
 			this->ProcessMatchmakerData(matchmakerData);
-	}
-	ImGui::End();
+	} else
+		ImGui::End();
 
 	return StateType::Menu;
 }

--- a/client/dfclient/src/websocket.cpp
+++ b/client/dfclient/src/websocket.cpp
@@ -163,16 +163,20 @@ int WebSocketBeast::Connect(std::string& fullAddress) {
 	auto host = address.substr(0, colon);
 	auto port = address.substr(colon + 1, address.size());
 	auto const results = resolver.resolve(host, port);
-	auto ep = net::connect(ws.next_layer(), results);
-	host += ':' + std::to_string(ep.port());
-	ws.set_option(websocket::stream_base::decorator(
-		[](websocket::request_type& req)
-		{
-			req.set(http::field::user_agent,
-				std::string(BOOST_BEAST_VERSION_STRING) +
-					" websocket-client-coro");
-		}));
-	ws.handshake(host, "/");
+	try {
+		auto ep = net::connect(ws.next_layer(), results);
+		host += ':' + std::to_string(ep.port());
+		ws.set_option(websocket::stream_base::decorator(
+			[](websocket::request_type& req)
+			{
+				req.set(http::field::user_agent,
+					std::string(BOOST_BEAST_VERSION_STRING) +
+						" websocket-client-coro");
+			}));
+		ws.handshake(host, "/");
+	} catch (std::exception e) {
+		return -1;
+	}
 
 	webSocketManager._ws->toBeOpened = true;
 

--- a/client/recmake_dfclient_native.sh
+++ b/client/recmake_dfclient_native.sh
@@ -14,6 +14,7 @@ cp ./nCine-external/lib/libpng16d.so.16 dfclient-native/
 cp ./nCine-external/lib/libwebp.so.7 dfclient-native/
 cp ./nCine-external/lib/liblua5.3.so dfclient-native/
 cp /usr/local/lib/libboost_system.so.1.74.0 dfclient-native/
+cp ./dfclient/deadfish.ini.example dfclient-native/deadfish.ini
 
 if [ "$1" != "--keep" ]
 then

--- a/env/build-server-prod-docker.sh
+++ b/env/build-server-prod-docker.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-docker exec --user ubuntu -it deadfish-env bash -c 'cd /deadfish/levelpacker && ./levelpacker.py && cd /deadfish/server && mkdir -p build-prod && cd build-prod && make -j && cp /usr/lib/x86_64-linux-gnu/libBox2D.so.2.3.0 . && cp /usr/local/lib/libboost_system.so.1.74.0 . && cp /usr/local/lib/libboost_program_options.so.1.74.0 .'
+docker exec --user ubuntu -it deadfish-env bash -c 'cd /deadfish/levelpacker && ./levelpacker.py && cd /deadfish/server && rm -rf build-prod && mkdir build-prod && cd build-prod && cmake .. && make -j && cp /usr/lib/x86_64-linux-gnu/libBox2D.so.2.3.0 . && cp /usr/local/lib/libboost_system.so.1.74.0 . && cp /usr/local/lib/libboost_program_options.so.1.74.0 .'
 
 cd ../server/build-prod
 cp deadfishserver ../../env/deadfish-server
@@ -12,6 +12,8 @@ cd ../env/deadfish-server
 rm -rf levels
 mkdir levels
 cp ../../levels/*.bin levels
+
+eval $(minikube -p agones docker-env)
 
 docker rmi deadfish-server || true
 docker build --tag deadfish-server .

--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -1,4 +1,4 @@
-SET (CMAKE_CXX_FLAGS                "-Wall -Wpedantic -Wextra -g -O0")
+SET (CMAKE_CXX_FLAGS                "-Wall -Wpedantic -Wextra -g")
 
 cmake_minimum_required(VERSION 3.0.0)
 project(deadfishserver VERSION 0.1.0)

--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -1,24 +1,4 @@
-# set clang
-
-SET (CMAKE_C_COMPILER             "/usr/bin/clang")
-SET (CMAKE_C_FLAGS                "-Wall -Wpedantic -Wextra -std=c99 -g -O0")
-SET (CMAKE_C_FLAGS_DEBUG          "-g -O0")
-SET (CMAKE_C_FLAGS_MINSIZEREL     "-Os -DNDEBUG")
-SET (CMAKE_C_FLAGS_RELEASE        "-O4 -DNDEBUG")
-SET (CMAKE_C_FLAGS_RELWITHDEBINFO "-O2 -g")
-
-SET (CMAKE_CXX_COMPILER             "/usr/bin/clang++")
 SET (CMAKE_CXX_FLAGS                "-Wall -Wpedantic -Wextra -g -O0")
-SET (CMAKE_CXX_FLAGS_DEBUG          "-g -O0")
-SET (CMAKE_CXX_FLAGS_MINSIZEREL     "-Os -DNDEBUG")
-SET (CMAKE_CXX_FLAGS_RELEASE        "-O4 -DNDEBUG")
-SET (CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O2 -g")
-
-SET (CMAKE_AR      "/usr/bin/llvm-ar")
-SET (CMAKE_LINKER  "/usr/bin/llvm-ld")
-SET (CMAKE_NM      "/usr/bin/llvm-nm")
-SET (CMAKE_OBJDUMP "/usr/bin/llvm-objdump")
-SET (CMAKE_RANLIB  "/usr/bin/llvm-ranlib")
 
 cmake_minimum_required(VERSION 3.0.0)
 project(deadfishserver VERSION 0.1.0)

--- a/server/agones.cpp
+++ b/server/agones.cpp
@@ -93,6 +93,7 @@ bool dfAgones::Start()
 void dfAgones::Shutdown() {
 	if (!sdk)
 		return;
+	std::cout << "performing agones shutdown\n";
 	sdk->Shutdown();
 }
 

--- a/server/deadfish.cpp
+++ b/server/deadfish.cpp
@@ -13,18 +13,18 @@ HidingSpot::HidingSpot(const FlatBuffGenerated::HidingSpot* fb_Hs) {
 
 	b2FixtureDef fixtureDef;
 	fixtureDef.isSensor = true; // makes hiding spot detect collision but allow movement
+	b2CircleShape circleShape;
+	b2PolygonShape boxShape;
+	b2PolygonShape polyShape;
 	if (!fb_Hs->polyverts()) {
 		if(fb_Hs->isCircle()){
-			b2CircleShape circleShape;
 			circleShape.m_radius = fb_Hs->size()->x() / 2.f;
 			fixtureDef.shape = &circleShape;
 		} else {
-			b2PolygonShape boxShape;
 			boxShape.SetAsBox(fb_Hs->size()->x()/2.f, fb_Hs->size()->y()/2.f);
 			fixtureDef.shape = &boxShape;
 		}
 	} else {
-		b2PolygonShape polyShape;
 		std::vector<b2Vec2> vertices;
 		auto fb_poly = fb_Hs->polyverts();
 		for (auto vert = fb_poly->begin(); vert != fb_poly->end(); ++vert) {
@@ -68,18 +68,19 @@ CollisionMask::CollisionMask(const FlatBuffGenerated::CollisionMask* fb_Col) {
 	body = gameState.b2world->CreateBody(&myBodyDef);
 
 	b2FixtureDef fixtureDef;
+	b2CircleShape circleShape;
+	b2PolygonShape polyShape;
+	b2PolygonShape boxShape;
+
 	if (!fb_Col->polyverts()) {
 		if(fb_Col->isCircle()){
-			b2CircleShape circleShape;
 			circleShape.m_radius = fb_Col->size()->x() / 2.f;
 			fixtureDef.shape = &circleShape;
 		} else {
-			b2PolygonShape boxShape;
 			boxShape.SetAsBox(fb_Col->size()->x()/2.f, fb_Col->size()->y()/2.f);
 			fixtureDef.shape = &boxShape;
 		}
 	} else {
-		b2PolygonShape polyShape;
 		std::vector<b2Vec2> vertices;
 		for (auto vert : *fb_Col->polyverts()) {
 			vertices.push_back(b2Vec2(vert->x(), vert->y()));


### PR DESCRIPTION
- choose between direct connection mode and matchmaking mode (and set default values) with an .ini file
- use a simple synchronous boost http server to connect to the matchmaker
- handle data received from the matchmaker
- minor fixes, including ui