### PR TITLE
Ink cloud visibility fix

### DIFF
--- a/server/game_thread.cpp
+++ b/server/game_thread.cpp
@@ -135,6 +135,8 @@ struct FOVCallback
 
 		if (data && data != target && player && !data->obstructsSight(player))
 			return 1.f;
+		if (target != data && dynamic_cast<InkParticle*>(target) && data && dynamic_cast<InkParticle*>(data))
+			return 1.f;
 		if (fraction < minfraction)
 		{
 			minfraction = fraction;


### PR DESCRIPTION
Made ink clouds not obscure each other while still obscuring vision of mobs.

![image](https://user-images.githubusercontent.com/33375219/114247566-b1f91500-9995-11eb-87e7-97c77063e375.png)
